### PR TITLE
fixed Query parameter 'end' always be null

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/value/request/Query.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/request/Query.java
@@ -122,9 +122,8 @@ public class Query extends JSONValue {
 					throw new IllegalArgumentException("the end time (" + this.endTime +
 							") must be greater than start time (" + this.startTime + ")" );
 				}
-			} else {
-				query.end = this.endTime;
 			}
+			query.end = this.endTime;
 			query.queries = this.subQueryList;
 			query.delete = this.delete;
 			query.msResolution = this.msResolution;


### PR DESCRIPTION
Bug from commit: 1aca44066ee10854d40027f4b12acb0166432dba

Signed-off-by: Scott Fan <fancp2007@gmail.com>