### PR TITLE
add the support for the new parameters of the request body of the api delete_meta

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/BalTSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/BalTSDBClient.java
@@ -742,6 +742,48 @@ public class BalTSDBClient implements TSDB {
     }
 
     @Override
+    public void deleteMeta(String metric, Map<String, String> tags, boolean deleteData, boolean recursive) throws HttpUnknowStatusException {
+        Exception exception = null;
+        for (int i = 0; i < MAX_RETRY_SIZE; i++) {
+            try {
+                client().deleteMeta(metric, tags, deleteData, recursive);
+                return;
+            } catch (Exception e) {
+                exception = e;
+            }
+        }
+        throw new RuntimeException(exception);
+    }
+
+    @Override
+    public void deleteMeta(String metric, List<String> fields, Map<String, String> tags, boolean deleteData, boolean recursive) throws HttpUnknowStatusException {
+        Exception exception = null;
+        for (int i = 0; i < MAX_RETRY_SIZE; i++) {
+            try {
+                client().deleteMeta(metric, fields, tags, deleteData, recursive);
+                return;
+            } catch (Exception e) {
+                exception = e;
+            }
+        }
+        throw new RuntimeException(exception);
+    }
+
+    @Override
+    public void deleteMeta(DeleteMetaRequest request) throws HttpUnknowStatusException {
+        Exception exception = null;
+        for (int i = 0; i < MAX_RETRY_SIZE; i++) {
+            try {
+                client().deleteMeta(request);
+                return;
+            } catch (Exception e) {
+                exception = e;
+            }
+        }
+        throw new RuntimeException(exception);
+    }
+
+    @Override
     public void ttl(int lifetime) throws HttpUnknowStatusException {
 
         Exception exception = null;

--- a/src/main/java/com/aliyun/hitsdb/client/TSDB.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDB.java
@@ -298,6 +298,40 @@ public interface TSDB extends Closeable {
     void deleteMeta(Timeline timeline) throws HttpUnknowStatusException;
 
     /**
+     * delete meta method
+     *
+     * @param metric metric
+     * @param tags   a map
+     * @param deleteData boolean flag to indicate whether to delete the data at the same time
+     * @param recursive boolean flag to indicate whether to delete the timelines recursively
+     * @throws HttpUnknowStatusException Exception
+     * @since 0.2.5
+     */
+    void deleteMeta(String metric, Map<String, String> tags, boolean deleteData, boolean recursive) throws HttpUnknowStatusException;
+
+    /**
+     * delete meta method
+     *
+     * @param metric metric
+     * @param fields fields that are under above metric
+     * @param tags   a map
+     * @param deleteData boolean flag to indicate whether to delete the data at the same time
+     * @param recursive boolean flag to indicate whether to delete the timelines recursively
+     * @throws HttpUnknowStatusException Exception
+     * @since 0.2.5
+     */
+    void deleteMeta(String metric, List<String> fields, Map<String, String> tags, boolean deleteData, boolean recursive) throws HttpUnknowStatusException;
+
+    /**
+     * delete meta method
+     *
+     * @param request the deleteMeta request object
+     * @throws HttpUnknowStatusException Exception
+     * @since 0.2.5
+     */
+    void deleteMeta(DeleteMetaRequest request) throws HttpUnknowStatusException;
+
+    /**
      * ttl method
      *
      * @param lifetime unit:seconds

--- a/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
@@ -250,6 +250,38 @@ public class TSDBClient implements TSDB {
         handleVoid(resultResponse);
     }
 
+    /**
+     * The following api are added in the 0.2.5 of the SDK.
+     *
+     * Ideally, we should implement the void deleteMeta(Timeline timeline, boolean deleteData, boolean recursive)
+     * as the prototype implementation and use it for the rest of the 5 api
+     *
+     * However, if the newly added 3 api issued against the earlier version of the TSDB server,
+     * the requests would not be recognised and a error would be returned.
+     * For the backward-compatibility, the implementations of the above 3 api would not change.
+     */
+    @Override
+    public void deleteMeta(String metric, Map<String, String> tags, boolean deleteData, boolean recursive) {
+        DeleteMetaRequest request = DeleteMetaRequest.metric(metric).tag(tags)
+                .deleteData(deleteData).recursive(recursive).build();
+        deleteMeta(request);
+    }
+
+    @Override
+    public void deleteMeta(String metric, List<String> fields, Map<String, String> tags, boolean deleteData, boolean recursive) {
+        DeleteMetaRequest request =
+                DeleteMetaRequest.metric(metric).tag(tags).fields(fields)
+                        .deleteData(deleteData).recursive(recursive).build();
+        deleteMeta(request);
+    }
+
+    @Override
+    public void deleteMeta(DeleteMetaRequest request) {
+        HttpResponse httpResponse = httpclient.post(HttpAPI.DELETE_META, request.toJSON());
+        ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.httpCompress);
+        handleVoid(resultResponse);
+    }
+
     @Override
     public List<TagResult> dumpMeta(String tagkey, String tagValuePrefix, int max) {
         DumpMetaValue dumpMetaValue = new DumpMetaValue(tagkey, tagValuePrefix, max);

--- a/src/main/java/com/aliyun/hitsdb/client/value/request/DeleteMetaRequest.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/request/DeleteMetaRequest.java
@@ -1,0 +1,87 @@
+package com.aliyun.hitsdb.client.value.request;
+
+import java.util.List;
+import java.util.Map;
+
+public class DeleteMetaRequest extends Timeline {
+    public static class Builder extends Timeline.Builder {
+        // the data is deleted at the same time by default
+        private boolean deleteData = true;
+        private boolean recursive;
+
+        public Builder(String metric) {
+            super(metric);
+            this.deleteData = true;   // the data is deleted at the same time by default
+            this.recursive = true;    // the timelines are deleted recursively by default
+        }
+
+        public Builder tag(String tagk, String tagv) {
+            super.tag(tagk, tagv);
+            return this;
+        }
+
+        public Builder tag(Map<String, String> tags) {
+            super.tag(tags);
+            return this;
+        }
+
+        public Builder fields(List<String> fields) {
+            super.fields(fields);
+            return this;
+        }
+
+        public Builder deleteData(boolean deleteData) {
+            this.deleteData = deleteData;
+            return this;
+        }
+
+        public Builder recursive(boolean recursive) {
+            this.recursive = recursive;
+            return this;
+        }
+
+        public DeleteMetaRequest build() {
+            DeleteMetaRequest request = new DeleteMetaRequest();
+
+            Timeline timeline = super.build();
+            request.setMetric(timeline.getMetric());
+            request.setTags(timeline.getTags());
+            if ((timeline.getFields() != null) && (!timeline.getFields().isEmpty())) {
+                request.setFields(timeline.getFields());
+            }
+            request.setDeleteData(this.deleteData);
+            request.setRecursive(this.recursive);
+
+            return request;
+        }
+    }
+
+    private boolean deleteData;
+    private boolean recursive;
+
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    public boolean isDeleteData() {
+        return deleteData;
+    }
+
+    public void setDeleteData(boolean deleteData) {
+        this.deleteData = deleteData;
+    }
+
+    public DeleteMetaRequest() {
+        super();
+        this.deleteData = true;
+        this.recursive = true;
+    }
+
+    public static DeleteMetaRequest.Builder metric(String metric) {
+        return new DeleteMetaRequest.Builder(metric);
+    }
+}

--- a/src/main/java/com/aliyun/hitsdb/client/value/request/Timeline.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/request/Timeline.java
@@ -72,11 +72,23 @@ public class Timeline extends JSONValue {
         return fields;
     }
 
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
     public String getMetric() {
         return metric;
     }
 
+    public void setMetric(String metric) {
+        this.metric = metric;
+    }
+
     public Map<String, String> getTags() {
         return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
     }
 }

--- a/src/test/java/com/aliyun/hitsdb/client/value/request/DeleteMetaRequestTest.java
+++ b/src/test/java/com/aliyun/hitsdb/client/value/request/DeleteMetaRequestTest.java
@@ -1,0 +1,29 @@
+package com.aliyun.hitsdb.client.value.request;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeleteMetaRequestTest {
+
+    @Test
+    public void testDeleteMetaRequest() {
+        DeleteMetaRequest deleteMetaRequest = DeleteMetaRequest.metric("testMetric")
+                .tag("tagk1", "tagv1").tag("tagk2", "tagv2")
+                .deleteData(false).recursive(true)
+                .build();
+        Assert.assertNotNull(deleteMetaRequest);
+
+        String json = deleteMetaRequest.toJSON();
+
+        JSONObject object = JSON.parseObject(json);
+
+        Assert.assertTrue("testMetric".equals(object.getString("metric")));
+        Assert.assertFalse(object.getBoolean("deleteData"));
+        Assert.assertTrue(object.getBoolean("recursive"));
+        Assert.assertNull(object.getJSONObject("fields"));
+
+        System.out.println(json);
+    }
+}


### PR DESCRIPTION
Some new parameters added for the Aliyun TSDB's api `delete_meta`, however, the SDK has not supported the newly added parameters yet. 

This pull request is supposed to fill the gap between the SDK and the server's api.

For the details of `api/delete_meta`, please refer to https://help.aliyun.com/document_detail/61694.html?spm=a2c4g.11186623.2.20.6646411cvZcxu8