### PR TITLE
fix the NPE of the TSDB#multiFieldQueryLast() for issue #42

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
@@ -1399,7 +1399,8 @@ public class TSDBClient implements TSDB {
      */
     @Override
     public List<MultiFieldQueryLastResult> multiFieldQueryLast(LastPointQuery lastPointQuery) throws HttpUnknowStatusException {
-        if (!lastPointQuery.getTupleFormat()) {
+        // set the tupleFormat to true automatically
+        if ((lastPointQuery.getTupleFormat()== null) || (!lastPointQuery.getTupleFormat())) {
             lastPointQuery.setTupleFormat(true);
         }
 


### PR DESCRIPTION
the `tupleFormat` field of LastPointQuery is `Boolean` type, so there is a chance that it returns null.  the code calling `getTupleFormat()` should handle the null situation.