### PR TITLE
it's meaningless to retry put if authentication failed for #50

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
@@ -61,15 +61,6 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
             this.hitsdbHttpClient.setSslEnable(true);
             errorRetry();
             return;
-        } else if (httpResponse.getStatusLine().getStatusCode() == org.apache.http.HttpStatus.SC_UNAUTHORIZED) {
-            try {
-                this.hitsdbHttpClient.checkAuthInfo();//认证信息校验避免进入多余的retry
-                errorRetry();
-                return;
-            } catch (HttpClientException e) {
-                this.failedWithResponse(e);
-                return;
-            }
         }
         ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.compress);
         HttpStatus httpStatus = resultResponse.getHttpStatus();

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/MultiFieldBatchPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/MultiFieldBatchPutHttpResponseCallback.java
@@ -54,15 +54,6 @@ public class MultiFieldBatchPutHttpResponseCallback implements FutureCallback<Ht
             this.hitsdbHttpClient.setSslEnable(true);
             errorRetry();
             return;
-        } else if (httpResponse.getStatusLine().getStatusCode() == org.apache.http.HttpStatus.SC_UNAUTHORIZED) {
-            try {
-                this.hitsdbHttpClient.checkAuthInfo();//认证信息校验避免进入多余的retry
-                errorRetry();
-                return;
-            } catch (HttpClientException e) {
-                this.failedWithResponse(e);
-                return;
-            }
         }
         ResultResponse resultResponse = ResultResponse.simplify(httpResponse, this.compress);
         HttpStatus httpStatus = resultResponse.getHttpStatus();


### PR DESCRIPTION
the original put callback logic is that if error occurred, retry it.

however, if an 401 error occurred, the put retry would fail again with the same credentials. so in this case, it is meaningless to do the retry. we should fail it directly. 