### PR TITLE
Support the "where" clause interface for MultiFieldSubQueryDetails according to the enhancement of TSDB

### DIFF
--- a/src/test/java/com/aliyun/hitsdb/client/TestHiTSDBClientMultiFieldFeatures.java
+++ b/src/test/java/com/aliyun/hitsdb/client/TestHiTSDBClientMultiFieldFeatures.java
@@ -7,6 +7,7 @@ import com.aliyun.hitsdb.client.value.response.MultiFieldQueryLastResult;
 import com.aliyun.hitsdb.client.value.response.MultiFieldQueryResult;
 import com.aliyun.hitsdb.client.value.type.Aggregator;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -227,6 +228,84 @@ public class TestHiTSDBClientMultiFieldFeatures {
             System.out.println("##### Multi-field Query Last Result : " + JSON.toJSONString(result));
         } else {
             System.out.println("##### Empty reply from HiTSDB server. ######");
+        }
+    }
+
+    /**
+     * test the basic behavior of the where interface of SDK
+     * @note it is required that the version of TSDB engine greater than v2.6.1
+     */
+    @Test
+    public void testMultiFieldQueryWithWhereClause() {
+        final String METRIC = "testMultiFieldQueryWithWhereClause", TAGK = "tagk";
+
+        try {
+            tsdb.deleteMeta(Timeline.metric(METRIC).build());
+            Thread.sleep(3000);
+        } catch (Exception e) {
+            System.out.println("Failed to delete time series during pre-testing stage. Continue.");
+        }
+
+        List<MultiFieldPoint> mpoints = new ArrayList<MultiFieldPoint>();
+        String [] strings = new String[]{"abc", "ABC", "11.11a"};
+
+        long startTime = 1514736000L;
+        // timeline1
+        for (int i = 0; i < 4; i++) {
+            mpoints.add(MultiFieldPoint.metric(METRIC)
+                    .tag(TAGK, "tagv1")
+                    .field("f1", 100 + i)
+                    .field("f2", 333.33)
+                    .field("f3", 300 - i * 100)
+                    .field("f4", strings[i % 3])
+                    .timestamp(startTime + i * 30).build());
+        }
+
+        // timeline2, no field3
+        mpoints.add(MultiFieldPoint.metric(METRIC)
+                .tag(TAGK, "tagv2")
+                .field("f1", 100)
+                .field("f2", 222.22)
+                .field("f4", strings[2 % 3])
+                .timestamp(startTime + 90).build());
+
+        // timeline2, no field4
+        mpoints.add(MultiFieldPoint.metric(METRIC)
+                .tag(TAGK, "tagv3")
+                .field("f1", 105)
+                .field("f2", 111.11)
+                .field("f3", 100)
+                .timestamp(startTime + 120).build());
+
+        tsdb.multiFieldPutSync(mpoints);
+
+
+        MultiFieldQuery mq = MultiFieldQuery.start(startTime)
+                .sub(MultiFieldSubQuery
+                        .metric(METRIC)
+                        .fieldsInfo(MultiFieldSubQueryDetails
+                                .aggregator(Aggregator.NONE)
+                                .field("*")
+                                .where("f3=100")
+                                .build())
+                        .build())
+                .build();
+        List<MultiFieldQueryResult> results = tsdb.multiFieldQuery(mq);
+
+        Assert.assertEquals(3, results.size());
+
+        for (MultiFieldQueryResult r: results) {
+            Assert.assertEquals(5, r.getColumns().size());
+
+            if (r.getTags().get(TAGK).equals("tagv1")) {
+                Assert.assertEquals(1, r.getValues().size());
+            } else if (r.getTags().get(TAGK).equals("tagv2")) {
+                Assert.assertEquals(0, r.getValues().size());
+            } else if (r.getTags().get(TAGK).equals("tagv3")) {
+                Assert.assertEquals(1, r.getValues().size());
+            } else {
+                Assert.fail("unexpected tag value retrieved: " + r.getTags().get(TAGK));
+            }
         }
     }
 }


### PR DESCRIPTION
add the "where" field for more accurate value filtering when user specified the querying fields as wildcard