### PR TITLE
version up the sdk to 0.3.0 due to a lot of features merged

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.aliyun</groupId>
 	<artifactId>hitsdb-client</artifactId>
-	<version>0.2.9</version>
+	<version>0.3.0</version>
 	<name>Aliyun TSDB SDK for Java</name>
 	<description>The Alibaba TSDB SDK for Java used for accessing High Performance Time Series Database</description>
 	<url>https://www.aliyun.com/product/hitsdb</url>


### PR DESCRIPTION
version up the sdk to 0.3.0 due to a lot of features merged

* hint feature
* where clause support
* byte array type support 
* etc.