### PR TITLE
add the async put method with a runtime callback according to IoT's requirement

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/BalTSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/BalTSDBClient.java
@@ -1,6 +1,7 @@
 package com.aliyun.hitsdb.client;
 
 import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
+import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
 import com.aliyun.hitsdb.client.callback.QueryCallback;
 import com.aliyun.hitsdb.client.exception.NotImplementedException;
 import com.aliyun.hitsdb.client.exception.http.HttpUnknowStatusException;
@@ -1247,5 +1248,15 @@ public class BalTSDBClient implements TSDB {
         } finally {
             SYNC.set(true);
         }
+    }
+
+    @Override
+    public void put(Collection<Point> points, AbstractBatchPutCallback batchPutCallback) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void multiFieldPut(Collection<MultiFieldPoint> points, AbstractMultiFieldBatchPutCallback batchPutCallback) {
+        throw new NotImplementedException();
     }
 }

--- a/src/main/java/com/aliyun/hitsdb/client/TSDB.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDB.java
@@ -1,6 +1,6 @@
 package com.aliyun.hitsdb.client;
 
-import com.aliyun.hitsdb.client.callback.QueryCallback;
+import com.aliyun.hitsdb.client.callback.*;
 import com.aliyun.hitsdb.client.exception.http.HttpUnknowStatusException;
 import com.aliyun.hitsdb.client.value.Result;
 import com.aliyun.hitsdb.client.value.request.*;
@@ -37,6 +37,17 @@ public interface TSDB extends Closeable {
      * @param points points
      */
     void put(Collection<Point> points);
+
+
+
+    /**
+     * Synchronous put points with a given callback
+     *
+     * @param points
+     * @param batchPutCallback
+     */
+    void put(Collection<Point> points, AbstractBatchPutCallback batchPutCallback);
+
 
     /**
      * Asynchronous multi-valued put point
@@ -580,6 +591,15 @@ public interface TSDB extends Closeable {
      * @param points points
      */
     void multiFieldPut(Collection<MultiFieldPoint> points);
+
+    /**
+     * Asynchronous put points with a given callback
+     *
+     * @param points
+     * @param batchPutCallback
+     */
+    void multiFieldPut(Collection<MultiFieldPoint> points, AbstractMultiFieldBatchPutCallback batchPutCallback);
+
 
     /**
      * /api/mquery endpoint

--- a/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
@@ -4,7 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.parser.Feature;
 import com.alibaba.fastjson.serializer.SerializerFeature;
-import com.aliyun.hitsdb.client.callback.QueryCallback;
+import com.aliyun.hitsdb.client.callback.*;
 import com.aliyun.hitsdb.client.callback.http.HttpResponseCallbackFactory;
 import com.aliyun.hitsdb.client.consumer.Consumer;
 import com.aliyun.hitsdb.client.consumer.ConsumerFactory;
@@ -17,6 +17,7 @@ import com.aliyun.hitsdb.client.http.response.ResultResponse;
 import com.aliyun.hitsdb.client.queue.DataQueue;
 import com.aliyun.hitsdb.client.queue.DataQueueFactory;
 import com.aliyun.hitsdb.client.util.LinkedHashMapUtils;
+import com.aliyun.hitsdb.client.util.Objects;
 import com.aliyun.hitsdb.client.value.JSONValue;
 import com.aliyun.hitsdb.client.value.Result;
 import com.aliyun.hitsdb.client.value.request.*;
@@ -1065,6 +1066,18 @@ public class TSDBClient implements TSDB {
         return putSync(points, Result.class);
     }
 
+    /**
+     * Synchronous put points with callback
+     *
+     * @param points
+     * @param batchPutCallback
+     */
+    @Override
+    public void put(Collection<Point> points, AbstractBatchPutCallback batchPutCallback) {
+        PointsCollection pc = new PointsCollection(points, batchPutCallback);
+        this.queue.sendPoints(pc);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Result> T putSync(Collection<Point> points, Class<T> resultType) {
@@ -1570,6 +1583,18 @@ public class TSDBClient implements TSDB {
         return multiFieldPutSync(points, Result.class);
     }
 
+    /**
+     * Synchronous put points with callback
+     *
+     * @param points
+     * @param batchPutCallback
+     */
+    @Override
+    public void multiFieldPut(Collection<MultiFieldPoint> points, AbstractMultiFieldBatchPutCallback batchPutCallback) {
+        PointsCollection pc = new PointsCollection(points, batchPutCallback);
+        this.queue.sendPoints(pc);
+    }
+
     @Override
     public void multiFieldPut(MultiFieldPoint point) {
         this.queue.sendMultiFieldPoint(point);
@@ -1756,6 +1781,7 @@ public class TSDBClient implements TSDB {
 
     @Override
     public void flush() {
+        //TODO: it flushes the single field point only, currently
         final Point[] points = this.queue.getPoints();
         if (points == null || points.length == 0) {
             return;

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/AbstractBatchPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/AbstractBatchPutRunnable.java
@@ -1,0 +1,73 @@
+package com.aliyun.hitsdb.client.consumer;
+
+import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.callback.http.HttpResponseCallbackFactory;
+import com.aliyun.hitsdb.client.http.HttpAddressManager;
+import com.aliyun.hitsdb.client.http.HttpClient;
+import com.aliyun.hitsdb.client.http.semaphore.SemaphoreManager;
+import com.aliyun.hitsdb.client.queue.DataQueue;
+import com.aliyun.hitsdb.client.util.guava.RateLimiter;
+import com.aliyun.hitsdb.client.value.request.Point;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public abstract class AbstractBatchPutRunnable {
+    /**
+     * 缓冲队列
+     */
+    protected final DataQueue dataQueue;
+    /**
+     * Http客户端
+     */
+    protected final HttpClient tsdbHttpClient;
+    /**
+     * 消费者队列控制器。
+     * 在优雅关闭中，若消费者队列尚未结束，则CountDownLatch用于阻塞close()方法。
+     */
+    protected final CountDownLatch countDownLatch;
+    protected final Config config;
+    protected final SemaphoreManager semaphoreManager;
+    protected final HttpAddressManager httpAddressManager;
+    /**
+     * 回调包装与构造工厂
+     */
+    protected final HttpResponseCallbackFactory httpResponseCallbackFactory;
+    /**
+     * 每批次数据点个数
+     */
+    protected int batchSize;
+    /**
+     * 批次提交间隔，单位：毫秒
+     */
+    protected int batchPutTimeLimit;
+    protected final RateLimiter rateLimiter;
+
+    public AbstractBatchPutRunnable(DataQueue dataQueue, HttpClient httpclient, CountDownLatch countDownLatch, Config config, RateLimiter rateLimiter) {
+        this.dataQueue = dataQueue;
+        this.tsdbHttpClient = httpclient;
+        this.countDownLatch = countDownLatch;
+        this.batchSize = config.getBatchPutSize();
+        this.batchPutTimeLimit = config.getBatchPutTimeLimit();
+        this.config = config;
+        this.semaphoreManager = tsdbHttpClient.getSemaphoreManager();
+        this.httpAddressManager = tsdbHttpClient.getHttpAddressManager();
+        this.rateLimiter = rateLimiter;
+        this.httpResponseCallbackFactory = tsdbHttpClient.getHttpResponseCallbackFactory();
+    }
+
+    protected String getAddressAndSemaphoreAcquire() {
+        String address;
+        while (true) {
+            address = httpAddressManager.getAddress();
+            boolean acquire = this.semaphoreManager.acquire(address);
+            if (!acquire) {
+                continue;
+            } else {
+                break;
+            }
+        }
+        return address;
+    }
+}

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/BatchPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/BatchPutRunnable.java
@@ -27,65 +27,18 @@ import com.aliyun.hitsdb.client.queue.DataQueue;
 import com.aliyun.hitsdb.client.value.request.Point;
 import com.aliyun.hitsdb.client.util.guava.RateLimiter;
 
-public class BatchPutRunnable implements Runnable {
+public class BatchPutRunnable extends AbstractBatchPutRunnable implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchPutRunnable.class);
-
-    /**
-     * 缓冲队列
-     */
-    private final DataQueue dataQueue;
-
-    /**
-     * Http客户端
-     */
-    private final HttpClient tsdbHttpClient;
 
     /**
      * 批量提交回调
      */
     private final AbstractBatchPutCallback<?> batchPutCallback;
 
-    /**
-     * 消费者队列控制器。
-     * 在优雅关闭中，若消费者队列尚未结束，则CountDownLatch用于阻塞close()方法。
-     */
-    private final CountDownLatch countDownLatch;
-
-    /**
-     * 每批次数据点个数
-     */
-    private int batchSize;
-
-    /**
-     * 批次提交间隔，单位：毫秒
-     */
-    private int batchPutTimeLimit;
-
-    /**
-     * 回调包装与构造工厂
-     */
-    private final HttpResponseCallbackFactory httpResponseCallbackFactory;
-
-    private final Config config;
-
-    private final SemaphoreManager semaphoreManager;
-
-    private final HttpAddressManager httpAddressManager;
-
-    private RateLimiter rateLimiter;
 
     public BatchPutRunnable(DataQueue dataQueue, HttpClient httpclient, Config config, CountDownLatch countDownLatch, RateLimiter rateLimiter) {
-        this.dataQueue = dataQueue;
-        this.tsdbHttpClient = httpclient;
-        this.semaphoreManager = tsdbHttpClient.getSemaphoreManager();
-        this.httpAddressManager = tsdbHttpClient.getHttpAddressManager();
+        super(dataQueue, httpclient, countDownLatch, config, rateLimiter);
         this.batchPutCallback = config.getBatchPutCallback();
-        this.batchSize = config.getBatchPutSize();
-        this.batchPutTimeLimit = config.getBatchPutTimeLimit();
-        this.config = config;
-        this.countDownLatch = countDownLatch;
-        this.rateLimiter = rateLimiter;
-        this.httpResponseCallbackFactory = tsdbHttpClient.getHttpResponseCallbackFactory();
     }
 
     @Override
@@ -161,20 +114,6 @@ public class BatchPutRunnable implements Runnable {
         if (readyClose) {
             this.countDownLatch.countDown();
         }
-    }
-
-    private String getAddressAndSemaphoreAcquire() {
-        String address;
-        while (true) {
-            address = httpAddressManager.getAddress();
-            boolean acquire = this.semaphoreManager.acquire(address);
-            if (!acquire) {
-                continue;
-            } else {
-                break;
-            }
-        }
-        return address;
     }
 
 

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/PointsCollectionPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/PointsCollectionPutRunnable.java
@@ -1,0 +1,150 @@
+package com.aliyun.hitsdb.client.consumer;
+
+import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.callback.*;
+import com.aliyun.hitsdb.client.http.HttpAPI;
+import com.aliyun.hitsdb.client.http.HttpClient;
+import com.aliyun.hitsdb.client.queue.DataQueue;
+import com.aliyun.hitsdb.client.util.guava.RateLimiter;
+import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
+import com.aliyun.hitsdb.client.value.request.Point;
+import com.aliyun.hitsdb.client.value.request.PointsCollection;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class PointsCollectionPutRunnable extends AbstractBatchPutRunnable implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PointsCollectionPutRunnable.class);
+
+    public PointsCollectionPutRunnable(DataQueue dataQueue, HttpClient httpclient, CountDownLatch countDownLatch, Config config, RateLimiter rateLimiter) {
+        super(dataQueue, httpclient, countDownLatch, config, rateLimiter);
+    }
+
+    /**
+     * When an object implementing interface <code>Runnable</code> is used
+     * to create a thread, starting the thread causes the object's
+     * <code>run</code> method to be called in that separately executing
+     * thread.
+     * <p>
+     * The general contract of the method <code>run</code> is that it may
+     * take any action whatsoever.
+     *
+     * @see Thread#run()
+     */
+    @Override
+    public void run() {
+        boolean readyClose = false;
+        int waitTimeLimit = batchPutTimeLimit / 3;
+
+        while (true) {
+            if (readyClose) {
+                break;
+            }
+
+            long t0 = System.currentTimeMillis();
+            PointsCollection points;
+            try {
+                points = dataQueue.receivePoints(waitTimeLimit);
+                if ((points == null) && (!readyClose)) {
+                    continue;
+                }
+            } catch (InterruptedException itex) {
+                readyClose = true;
+                LOGGER.info("The thread {} is interrupted. cause {}", Thread.currentThread().getName(), itex.getMessage());
+                break;
+            }
+
+            // acquire the permit before actually sending the post
+            if (this.rateLimiter != null) {
+                this.rateLimiter.acquire();
+            }
+
+            // serialization
+            String strJson = points.toJSON();
+
+            // 发送
+            sendHttpRequest(points, strJson);
+        }
+
+        if (readyClose) {
+            this.countDownLatch.countDown();
+        }
+    }
+
+    private void sendHttpRequest(final PointsCollection points, String strJson) {
+        if (points.isEmpty()) {
+            LOGGER.warn("PointsCollection is empty, nothing to post");
+        }
+
+        String address = getAddressAndSemaphoreAcquire();
+
+        Map<String, String> paramsMap = new HashMap<String, String>();
+        if (points.getSimplePointBatchCallbak() != null) {
+            AbstractBatchPutCallback scallback = points.getSimplePointBatchCallbak();
+
+
+            if (scallback != null) {
+                if (scallback instanceof BatchPutCallback) {
+                } else if (scallback instanceof BatchPutSummaryCallback) {
+                    paramsMap.put("summary", "true");
+                } else if (scallback instanceof BatchPutDetailsCallback) {
+                    paramsMap.put("details", "true");
+                }
+            }
+
+            List<Point> slist = points.asSingleFieldPoints();
+            FutureCallback<HttpResponse> postHttpCallback = this.httpResponseCallbackFactory
+                    .createBatchPutDataCallback(
+                            address,
+                            scallback,
+                            slist,
+                            config,
+                    config.getBatchPutRetryCount());
+
+            try {
+                tsdbHttpClient.postToAddress(address, HttpAPI.PUT, strJson, paramsMap, postHttpCallback);
+            } catch (Exception ex) {
+                this.semaphoreManager.release(address);
+                scallback.failed(address, slist, ex);
+            }
+
+        } else {
+            AbstractMultiFieldBatchPutCallback mcallback = points.getMultiFieldBatchPutCallback();
+
+            if (mcallback != null) {
+                if (mcallback instanceof MultiFieldBatchPutCallback) {
+                } else if (mcallback instanceof MultiFieldBatchPutSummaryCallback) {
+                    paramsMap.put("summary", "true");
+                } else if (mcallback instanceof MultiFieldBatchPutDetailsCallback) {
+                    paramsMap.put("details", "true");
+                }
+
+
+                List<MultiFieldPoint> mlist = points.asMultiFieldPoints();
+                FutureCallback<HttpResponse> postHttpCallback = this.httpResponseCallbackFactory
+                        .createMultiFieldBatchPutDataCallback(
+                                address,
+                                mcallback,
+                                mlist,
+                                config,
+                                config.getBatchPutRetryCount());
+
+                try {
+                    tsdbHttpClient.postToAddress(address, HttpAPI.MPUT, strJson, paramsMap, postHttpCallback);
+                } catch (Exception ex) {
+                    this.semaphoreManager.release(address);
+                    mcallback.failed(address, mlist, ex);
+                }
+            } else {
+                LOGGER.warn("No batch callback at all");
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/aliyun/hitsdb/client/queue/DataQueue.java
+++ b/src/main/java/com/aliyun/hitsdb/client/queue/DataQueue.java
@@ -2,6 +2,7 @@ package com.aliyun.hitsdb.client.queue;
 
 import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
 import com.aliyun.hitsdb.client.value.request.Point;
+import com.aliyun.hitsdb.client.value.request.PointsCollection;
 
 public interface DataQueue {
     void send(Point point);
@@ -16,6 +17,12 @@ public interface DataQueue {
     MultiFieldPoint receiveMultiFieldPoint() throws InterruptedException;
 
     MultiFieldPoint receiveMultiFieldPoint(int timeout) throws InterruptedException;
+
+    void sendPoints(PointsCollection points);
+
+    PointsCollection receivePoints() throws InterruptedException;
+
+    PointsCollection receivePoints(int timeout) throws InterruptedException;
 
     void forbiddenSend();
 

--- a/src/main/java/com/aliyun/hitsdb/client/value/request/PointsCollection.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/request/PointsCollection.java
@@ -1,0 +1,71 @@
+package com.aliyun.hitsdb.client.value.request;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONField;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
+import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
+import com.aliyun.hitsdb.client.util.Objects;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class PointsCollection extends ArrayList<AbstractPoint> {
+    @JSONField(serialize = false)
+    private final AbstractBatchPutCallback  simplePointBatchCallbak;
+    @JSONField(serialize = false)
+    private final AbstractMultiFieldBatchPutCallback  multiFieldBatchPutCallback;
+
+    public PointsCollection(Collection<Point> points, AbstractBatchPutCallback callback) {
+        Objects.requireNonNull(points);
+        Objects.requireNonNull(callback);
+
+        addAll(points);
+        this.simplePointBatchCallbak = callback;
+        this.multiFieldBatchPutCallback = null;
+    }
+
+    public PointsCollection(Collection<MultiFieldPoint> multiFieldPoints, AbstractMultiFieldBatchPutCallback callback) {
+        Objects.requireNonNull(multiFieldPoints);
+        Objects.requireNonNull(callback);
+
+        addAll(multiFieldPoints);
+        this.simplePointBatchCallbak = null;
+        this.multiFieldBatchPutCallback = callback;
+    }
+
+    public AbstractBatchPutCallback getSimplePointBatchCallbak() {
+        return simplePointBatchCallbak;
+    }
+
+    public AbstractMultiFieldBatchPutCallback getMultiFieldBatchPutCallback() {
+        return multiFieldBatchPutCallback;
+    }
+
+    public List<Point> asSingleFieldPoints() {
+        List<Point> retval = new ArrayList<Point>(this.size());
+        for (AbstractPoint p : this) {
+            if (!(p instanceof Point)) {
+                throw new IllegalStateException("it's not a SingleFieldPoint collection");
+            }
+            retval.add((Point)p);
+        }
+        return retval;
+    }
+
+    public List<MultiFieldPoint> asMultiFieldPoints() {
+        List<MultiFieldPoint> retval = new ArrayList<MultiFieldPoint>(this.size());
+        for (AbstractPoint p : this) {
+            if (!(p instanceof MultiFieldPoint)) {
+                throw new IllegalStateException("it's not a MultiFieldPoint collection");
+            }
+            retval.add((MultiFieldPoint)p);
+        }
+        return retval;
+    }
+
+    public String toJSON() {
+        return JSON.toJSONString(this, SerializerFeature.DisableCircularReferenceDetect, SerializerFeature.SortField, SerializerFeature.SortField.MapSortField);
+    }
+}

--- a/src/test/java/com/aliyun/hitsdb/client/callback/TestPutWithTemperaryCallback.java
+++ b/src/test/java/com/aliyun/hitsdb/client/callback/TestPutWithTemperaryCallback.java
@@ -1,0 +1,118 @@
+package com.aliyun.hitsdb.client.callback;
+
+import com.aliyun.hitsdb.client.TSDB;
+import com.aliyun.hitsdb.client.TSDBClientFactory;
+import com.aliyun.hitsdb.client.TSDBConfig;
+import com.aliyun.hitsdb.client.exception.http.HttpClientInitException;
+import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
+import com.aliyun.hitsdb.client.value.request.Point;
+import com.aliyun.hitsdb.client.value.response.batch.MultiFieldDetailsResult;
+import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TestPutWithTemperaryCallback {
+    TSDB tsdb;
+
+    @Before
+    public void init() throws HttpClientInitException, IOException {
+        System.out.println("开始运行");
+
+        TSDBConfig config = TSDBConfig
+                .address("127.0.0.1", 8242)
+                .httpConnectionPool(100)
+                .config();
+
+        tsdb = TSDBClientFactory.connect(config);
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        BatchPutSummaryCallback pcb = new BatchPutSummaryCallback() {
+
+            @Override
+            public void response(String address, List<Point> input, SummaryResult result) {
+                int success = result.getSuccess();
+                int failed = result.getFailed();
+                System.out.println("write data successfully, success: " + success + ", failure: " + failed);
+            }
+
+            @Override
+            public void failed(String address, List<Point> input, Exception ex) {
+                System.out.println("failed to write points, " + ex.getMessage());
+            }
+
+        };
+
+        List<Point> points = new ArrayList<Point>();
+        for(int i = 0;i<1000;i++) {
+            points.add(createPoint(i%4,1.123));
+        }
+
+        tsdb.put(points, pcb);
+
+        tsdb.put(Collections.EMPTY_LIST, pcb);
+
+        Thread.sleep(1000);
+    }
+
+    @Test
+    public void testMultiField() throws InterruptedException {
+        MultiFieldBatchPutDetailsCallback pcb = new MultiFieldBatchPutDetailsCallback() {
+
+            @Override
+            public void response(String address, List<MultiFieldPoint> input, MultiFieldDetailsResult result) {
+                int success = result.getSuccess();
+                int failed = result.getFailed();
+                System.out.println("write multi-field data successfully, success: " + success + ", failure: " + failed);
+            }
+
+            @Override
+            public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                System.out.println("failed to write multi-field points, " + ex.getMessage());
+            }
+
+        };
+
+        List<MultiFieldPoint> points = new ArrayList<MultiFieldPoint>();
+        for(int i = 0;i<1000;i++) {
+            points.add(createMFPoint(i%4,1.123, 4.432));
+        }
+
+        tsdb.multiFieldPut(points, pcb);
+
+        MultiFieldBatchPutDetailsCallback pcb2 = new MultiFieldBatchPutDetailsCallback() {
+
+            @Override
+            public void response(String address, List<MultiFieldPoint> input, MultiFieldDetailsResult result) {
+                System.out.println("empty callback");
+            }
+
+            @Override
+            public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                System.out.println("nothing to fail");
+            }
+
+        };
+
+        tsdb.multiFieldPut(Collections.EMPTY_LIST, pcb2);
+
+        Thread.sleep(1000);
+    }
+
+    public Point createPoint(int tag, double value) {
+        int t = (int) (System.currentTimeMillis() / 1000);
+        return Point.metric("TestPutWithTemperaryCallback").tag("tag", String.valueOf(tag)).value(t, value).build();
+    }
+
+    public MultiFieldPoint createMFPoint(int tag, double value1, double value2) {
+        int t = (int) (System.currentTimeMillis() / 1000);
+        return MultiFieldPoint.metric("TestPutWithTemperaryCallback").tag("tag", String.valueOf(tag))
+                .field("f1", value1).field("f2", value2).timestamp(t).build();
+    }
+}

--- a/src/test/java/com/aliyun/hitsdb/client/value/request/PointsCollectionTest.java
+++ b/src/test/java/com/aliyun/hitsdb/client/value/request/PointsCollectionTest.java
@@ -1,0 +1,162 @@
+package com.aliyun.hitsdb.client.value.request;
+
+import com.aliyun.hitsdb.client.callback.BatchPutSummaryCallback;
+import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutDetailsCallback;
+import com.aliyun.hitsdb.client.value.response.batch.MultiFieldDetailsResult;
+import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class PointsCollectionTest {
+    @Test
+    public void createNormally() {
+        {
+            Set<Point> points = new LinkedHashSet<Point>() {{
+                long timestamp = 1608480000L;
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp).value(12.34).build());
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp + 30).value(43.21).build());
+            }};
+
+            BatchPutSummaryCallback pcb = new BatchPutSummaryCallback() {
+
+                @Override
+                public void response(String address, List<Point> input, SummaryResult result) {
+                    int success = result.getSuccess();
+                    int failed = result.getFailed();
+                    System.out.println("write data successfully, success: " + success + ", failure: " + failed);
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    System.out.println("failed to write points, " + ex.getMessage());
+                }
+
+            };
+
+            PointsCollection pc = new PointsCollection(points, pcb);
+
+            Assert.assertEquals(pc.size(), points.size());
+            Assert.assertTrue(pc.toJSON(), pc.toJSON().equals("[{\"metric\":\"createNormally\",\"tags\":{\"tag1\":\"tagv1\"},\"timestamp\":1608480000,\"value\":12.34},{\"metric\":\"createNormally\",\"tags\":{\"tag1\":\"tagv1\"},\"timestamp\":1608480030,\"value\":43.21}]"));
+            Assert.assertEquals(pc.asSingleFieldPoints().size(), points.size());
+        }
+
+
+        {
+            final long timestamp = 1608480000L;
+            List<MultiFieldPoint> points = new ArrayList<MultiFieldPoint>() {{
+                add(MultiFieldPoint.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp).field("f1", 12.34).build());
+                add(MultiFieldPoint.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp + 30).field("f1", 43.21).build());
+            }};
+
+            MultiFieldBatchPutDetailsCallback pcb = new MultiFieldBatchPutDetailsCallback() {
+
+                @Override
+                public void response(String address, List<MultiFieldPoint> input, MultiFieldDetailsResult result) {
+                    int success = result.getSuccess();
+                    int failed = result.getFailed();
+                    System.out.println("write data successfully, success: " + success + ", failure: " + failed);
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    System.out.println("failed to write points, " + ex.getMessage());
+                }
+
+            };
+
+            PointsCollection pc = new PointsCollection(points, pcb);
+
+            Assert.assertEquals(pc.size(), points.size());
+            Assert.assertTrue(pc.toJSON(), pc.toJSON().equals("[{\"fields\":{\"f1\":12.34},\"metric\":\"createNormally\",\"tags\":{\"tag1\":\"tagv1\"},\"timestamp\":1608480000},{\"fields\":{\"f1\":43.21},\"metric\":\"createNormally\",\"tags\":{\"tag1\":\"tagv1\"},\"timestamp\":1608480030}]"));
+            Assert.assertEquals(pc.asMultiFieldPoints().size(), points.size());
+        }
+    }
+
+    @Test
+    public void createAbnormally() {
+        {
+            Set<Point> points = new LinkedHashSet<Point>() {{
+                long timestamp = 1608480000L;
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp).value(12.34).build());
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp + 30).value(43.21).build());
+            }};
+
+            try {
+                PointsCollection pc = new PointsCollection(points, null);
+                Assert.fail("constructor should not succeed");
+            } catch (NullPointerException npe) {
+                ;;
+            }
+        }
+
+        {
+            final long timestamp = 1608480000L;
+
+            MultiFieldBatchPutDetailsCallback pcb = new MultiFieldBatchPutDetailsCallback() {
+
+                @Override
+                public void response(String address, List<MultiFieldPoint> input, MultiFieldDetailsResult result) {
+                    int success = result.getSuccess();
+                    int failed = result.getFailed();
+                    System.out.println("write data successfully, success: " + success + ", failure: " + failed);
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    System.out.println("failed to write points, " + ex.getMessage());
+                }
+
+            };
+
+            try {
+                PointsCollection pc = new PointsCollection(null, pcb);
+                Assert.fail("constructor should not succeed");
+            } catch (NullPointerException npe) {
+                ;;
+            }
+        }
+
+        {
+            Set<Point> points = new LinkedHashSet<Point>() {{
+                long timestamp = 1608480000L;
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp).value(12.34).build());
+                add(Point.metric("createNormally").tag("tag1", "tagv1").timestamp(timestamp + 30).value(43.21).build());
+            }};
+
+            BatchPutSummaryCallback pcb = new BatchPutSummaryCallback() {
+
+                @Override
+                public void response(String address, List<Point> input, SummaryResult result) {
+                    int success = result.getSuccess();
+                    int failed = result.getFailed();
+                    System.out.println("write data successfully, success: " + success + ", failure: " + failed);
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    System.out.println("failed to write points, " + ex.getMessage());
+                }
+
+            };
+
+            PointsCollection pc = new PointsCollection(points, pcb);
+            pc.add(MultiFieldPoint.metric("createNormally").tag("tag1", "tagv1").timestamp(1608480000L + 60).field("f1", 43.21).build());
+
+            try {
+                pc.asSingleFieldPoints();
+                Assert.fail("asSingleFieldPoints() should not succeed");
+            } catch (IllegalStateException isex) {
+                ;;
+            }
+
+            try {
+                pc.asMultiFieldPoints();
+                Assert.fail("asMultiFieldPoints() should not succeed");
+            } catch (IllegalStateException isex) {
+                ;;
+            }
+        }
+    }
+}


### PR DESCRIPTION
add two async write method for TSDBClient

* `void put(Collection<Point> points, AbstractBatchPutCallback batchPutCallback)`
* `void multiFieldPut(Collection<MultiFieldPoint> points, AbstractMultiFieldBatchPutCallback batchPutCallback);`

which would allow the developers to pass a runtime callback when they calls async write method, despite whether they have registered a callback for the config. 