### PR TITLE
fix ignore errors call back bugs for put/mput

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/consumer/BatchPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/BatchPutRunnable.java
@@ -8,16 +8,13 @@ import java.util.concurrent.CountDownLatch;
 
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.callback.*;
 import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alibaba.fastjson.JSON;
-import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
-import com.aliyun.hitsdb.client.callback.BatchPutCallback;
-import com.aliyun.hitsdb.client.callback.BatchPutDetailsCallback;
-import com.aliyun.hitsdb.client.callback.BatchPutSummaryCallback;
 import com.aliyun.hitsdb.client.callback.http.HttpResponseCallbackFactory;
 import com.aliyun.hitsdb.client.http.HttpAPI;
 import com.aliyun.hitsdb.client.http.HttpAddressManager;
@@ -97,6 +94,8 @@ public class BatchPutRunnable implements Runnable {
                 paramsMap.put("summary", "true");
             } else if (batchPutCallback instanceof BatchPutDetailsCallback) {
                 paramsMap.put("details", "true");
+            } else if (batchPutCallback instanceof BatchPutIgnoreErrorsCallback) {
+                paramsMap.put("ignoreErrors", "true");
             }
         }
 

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/MultiFieldBatchPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/MultiFieldBatchPutRunnable.java
@@ -3,10 +3,7 @@ package com.aliyun.hitsdb.client.consumer;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.aliyun.hitsdb.client.Config;
-import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
-import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutCallback;
-import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutDetailsCallback;
-import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutSummaryCallback;
+import com.aliyun.hitsdb.client.callback.*;
 import com.aliyun.hitsdb.client.callback.http.HttpResponseCallbackFactory;
 import com.aliyun.hitsdb.client.http.HttpAPI;
 import com.aliyun.hitsdb.client.http.HttpAddressManager;
@@ -96,6 +93,8 @@ public class MultiFieldBatchPutRunnable implements Runnable {
                 paramsMap.put("summary", "true");
             } else if (multiFieldBatchPutCallback instanceof MultiFieldBatchPutDetailsCallback) {
                 paramsMap.put("details", "true");
+            } else if (multiFieldBatchPutCallback instanceof MultiFieldBatchPutIgnoreErrorsCallback) {
+                paramsMap.put("ignoreErrors", "true");
             }
         }
 


### PR DESCRIPTION
* for sync put/mput : 
use `tsdb.multiFieldPutSync(mpoint, MultiFieldIgnoreErrorsResult.class)` or `tsdb.putSync(point, IgnoreErrorsResult.class)` to ignore errors
* for async  put/mput : 
regist call back by **BatchPutIgnoreErrorsCallback** or **MultiFieldBatchPutIgnoreErrorsCallback**