### PR TITLE
add the support of summary & details for the callback of bad request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,18 @@
 			<version>1.7.21</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.1</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- Test -->
 		<dependency>

--- a/src/main/java/com/aliyun/hitsdb/client/callback/BatchPutDetailsCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/BatchPutDetailsCallback.java
@@ -2,6 +2,7 @@ package com.aliyun.hitsdb.client.callback;
 
 import java.util.List;
 
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
 import com.aliyun.hitsdb.client.value.request.Point;
 import com.aliyun.hitsdb.client.value.response.batch.DetailsResult;
 
@@ -10,4 +11,21 @@ public abstract class BatchPutDetailsCallback extends AbstractBatchPutCallback<D
     @Override
     public abstract void response(String address, List<Point> points, DetailsResult result);
 
+    /**
+     * the unique callback method for the scenario that error returned with detailed information of the error data points
+     * if the application want to handle this scenario, it should override this method
+     * @param result the detailed information contains the statistical information and error points, if any.
+     *               NOTICE!! result might be NULL
+     * @since 0.3.5
+     */
+    public void failed(String address, List<Point> points, HttpServerBadRequestException ex, DetailsResult result) {
+        // we CANNOT declare this method abstract because it would cause the application fail in the compile
+        // once the application just updated the version of the dependency to the aliyun-tsdb-java-sdk
+        //
+        // however, we CANNOT declare a default method in the interface com.aliyun.hitsdb.client.callback.Callback either,
+        // because we have to keep the compatibility to the language specification of java 6
+        //
+        // as a result, we make this method call the existing failed() method as its default behavior
+        failed(address, points, ex);
+    }
 }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/BatchPutSummaryCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/BatchPutSummaryCallback.java
@@ -2,6 +2,7 @@ package com.aliyun.hitsdb.client.callback;
 
 import java.util.List;
 
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
 import com.aliyun.hitsdb.client.value.request.Point;
 import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
 
@@ -9,4 +10,22 @@ public abstract class BatchPutSummaryCallback extends AbstractBatchPutCallback<S
 
     @Override
     public abstract void response(String address, List<Point> points, SummaryResult result);
+
+    /**
+     * the unique callback method for the scenario that error returned with summary information
+     * if the application want to handle this scenario, it should override this method
+     * @param result the detailed information contains the statistical information, if any.
+     *               NOTICE!! result might be NULL
+     * @since 0.3.5
+     */
+    public void failed(String address, List<Point> points, HttpServerBadRequestException ex, SummaryResult result) {
+        // we CANNOT declare this method abstract because it would cause the application fail in the compile
+        // once the application just updated the version of the dependency to the aliyun-tsdb-java-sdk
+        //
+        // however, we CANNOT declare a default method in the interface com.aliyun.hitsdb.client.callback.Callback either,
+        // because we have to keep the compatibility to the language specification of java 6
+        //
+        // as a result, we make this method call the existing failed() method as its default behavior
+        failed(address, points, ex);
+    }
 }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/MultiFieldBatchPutDetailsCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/MultiFieldBatchPutDetailsCallback.java
@@ -1,5 +1,6 @@
 package com.aliyun.hitsdb.client.callback;
 
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
 import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
 import com.aliyun.hitsdb.client.value.response.batch.MultiFieldDetailsResult;
 
@@ -9,5 +10,23 @@ public abstract class MultiFieldBatchPutDetailsCallback extends AbstractMultiFie
 
     @Override
     public abstract void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result);
+
+    /**
+     * the unique callback method for the scenario that error returned with detailed information of the error data points
+     * if the application want to handle this scenario, it should override this method
+     * @param result the detailed information contains the statistical information and error points, if any.
+     *               NOTICE!! result might be NULL
+     * @since 0.3.5
+     */
+    public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, MultiFieldDetailsResult result) {
+        // we CANNOT declare this method abstract because it would cause the application fail in the compile
+        // once the application just updated the version of the dependency to the aliyun-tsdb-java-sdk
+        //
+        // however, we CANNOT declare a default method in the interface com.aliyun.hitsdb.client.callback.Callback either,
+        // because we have to keep the compatibility to the language specification of java 6
+        //
+        // as a result, we make this method call the existing failed() method as its default behavior
+        failed(address, points, ex);
+    }
 
 }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/MultiFieldBatchPutSummaryCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/MultiFieldBatchPutSummaryCallback.java
@@ -1,5 +1,6 @@
 package com.aliyun.hitsdb.client.callback;
 
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
 import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
 import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
 
@@ -9,4 +10,21 @@ public abstract class MultiFieldBatchPutSummaryCallback extends AbstractMultiFie
 
     @Override
     public abstract void response(String address, List<MultiFieldPoint> points, SummaryResult result);
+
+    /**
+     * the unique callback method for the scenario that error returned with summary information
+     * @param result the detailed information contains the statistical information and error points, if any.
+     *               NOTICE!! result might be NULL
+     * @since 0.3.5
+     */
+    public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, SummaryResult result) {
+        // we CANNOT declare this method abstract because it would cause the application fail in the compile
+        // once the application just updated the version of the dependency to the aliyun-tsdb-java-sdk
+        //
+        // however, we CANNOT declare a default method in the interface com.aliyun.hitsdb.client.callback.Callback either,
+        // because we have to keep the compatibility to the language specification of java 6
+        //
+        // as a result, we make this method call the existing failed() method as its default behavior
+        failed(address, points, ex);
+    }
 }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
@@ -1,10 +1,13 @@
 package com.aliyun.hitsdb.client.callback.http;
 
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.List;
 
+import com.alibaba.fastjson.JSONException;
 import com.aliyun.hitsdb.client.Config;
 import com.aliyun.hitsdb.client.callback.BatchPutIgnoreErrorsCallback;
+import com.aliyun.hitsdb.client.exception.http.*;
 import com.aliyun.hitsdb.client.value.response.batch.IgnoreErrorsResult;
 import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
@@ -16,11 +19,6 @@ import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
 import com.aliyun.hitsdb.client.callback.BatchPutCallback;
 import com.aliyun.hitsdb.client.callback.BatchPutDetailsCallback;
 import com.aliyun.hitsdb.client.callback.BatchPutSummaryCallback;
-import com.aliyun.hitsdb.client.exception.http.HttpClientConnectionRefusedException;
-import com.aliyun.hitsdb.client.exception.http.HttpClientSocketTimeoutException;
-import com.aliyun.hitsdb.client.exception.http.HttpServerErrorException;
-import com.aliyun.hitsdb.client.exception.http.HttpServerNotSupportException;
-import com.aliyun.hitsdb.client.exception.http.HttpUnknowStatusException;
 import com.aliyun.hitsdb.client.http.HttpAPI;
 import com.aliyun.hitsdb.client.http.HttpAddressManager;
 import com.aliyun.hitsdb.client.http.HttpClient;
@@ -101,6 +99,10 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
                         ((BatchPutIgnoreErrorsCallback) batchPutCallback).response(this.address, pointList, ignoreErrorsResult);
                         return;
                     }
+                case ServerBadRequest:
+                    HttpServerBadRequestException bdex = new HttpServerBadRequestException(resultResponse);
+                    this.failedWithResponse(bdex);
+                    return;
                 case ServerNotSupport: {
                     // 服务器返回4xx错误
                     HttpServerNotSupportException ex = new HttpServerNotSupportException(resultResponse);
@@ -133,11 +135,37 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
      * 有响应的异常处理。
      *
      * @param ex
+     * @note  visible for testing only
      */
-    private void failedWithResponse(Exception ex) {
+    void failedWithResponse(Exception ex) {
         if (batchPutCallback == null) { // 无回调逻辑，则失败打印日志。
             LOGGER.error("No callback logic exception. address:" + this.address, ex);
         } else {
+            String responseContent = ex.getMessage();
+            if ((ex instanceof HttpServerBadRequestException) && (responseContent != null) && (!responseContent.isEmpty())) {
+                HttpServerBadRequestException bdex = (HttpServerBadRequestException)ex;
+                if (batchPutCallback instanceof BatchPutSummaryCallback) {
+                    SummaryResult summaryResult = null;
+                    try {
+                        summaryResult = JSON.parseObject(responseContent, SummaryResult.class);
+                    } catch (JSONException jex) {
+                        // not all the 400 error has summary information
+                        LOGGER.warn("failed to deserialize {} into SummaryResult", responseContent);
+                    }
+                    ((BatchPutSummaryCallback) batchPutCallback).failed(this.address, pointList, bdex, summaryResult);
+                    return;
+                } else if (batchPutCallback instanceof BatchPutDetailsCallback) {
+                    DetailsResult detailsResult = null;
+                    try {
+                        detailsResult = JSON.parseObject(responseContent, DetailsResult.class);
+                    } catch (JSONException jex) {
+                        // not all the 400 error has detailed information
+                        LOGGER.warn("failed to deserialize {} into DetailsResult", responseContent);
+                    }
+                    ((BatchPutDetailsCallback) batchPutCallback).failed(this.address, pointList, bdex, detailsResult);
+                    return;
+                }
+            }
             batchPutCallback.failed(this.address, pointList, ex);
         }
     }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/MultiFieldBatchPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/MultiFieldBatchPutHttpResponseCallback.java
@@ -1,6 +1,7 @@
 package com.aliyun.hitsdb.client.callback.http;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.aliyun.hitsdb.client.Config;
 import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
 import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutCallback;
@@ -96,6 +97,10 @@ public class MultiFieldBatchPutHttpResponseCallback implements FutureCallback<Ht
                         ((MultiFieldBatchPutIgnoreErrorsCallback) multiFieldBatchPutCallback).response(this.address, pointList, ignoreErrorsResult);
                         return;
                     }
+                case ServerBadRequest:
+                    HttpServerBadRequestException bdex = new HttpServerBadRequestException(resultResponse);
+                    this.failedWithResponse(bdex);
+                    return;
                 case ServerNotSupport: {
                     // 服务器返回4xx错误
                     HttpServerNotSupportException ex = new HttpServerNotSupportException(resultResponse);
@@ -128,11 +133,37 @@ public class MultiFieldBatchPutHttpResponseCallback implements FutureCallback<Ht
      * 有响应的异常处理。
      *
      * @param ex
+     * @note  visible just for testing
      */
-    private void failedWithResponse(Exception ex) {
+    void failedWithResponse(Exception ex) {
         if (multiFieldBatchPutCallback == null) { // 无回调逻辑，则失败打印日志。
             LOGGER.error("multi field no callback logic exception. address:" + this.address, ex);
         } else {
+            String responseContent = ex.getMessage();
+            if ((ex instanceof HttpServerBadRequestException) && (responseContent != null) && (!responseContent.isEmpty())) {
+                HttpServerBadRequestException bdex = (HttpServerBadRequestException)ex;
+                if (multiFieldBatchPutCallback instanceof MultiFieldBatchPutSummaryCallback) {
+                    SummaryResult summaryResult = null;
+                    try {
+                        summaryResult = JSON.parseObject(responseContent, SummaryResult.class);
+                    } catch (JSONException jex) {
+                        // not all the 400 error has summary information
+                        LOGGER.warn("failed to deserialize {} into SummaryResult", responseContent);
+                    }
+                    ((MultiFieldBatchPutSummaryCallback) multiFieldBatchPutCallback).failed(this.address, pointList, bdex, summaryResult);
+                    return;
+                } else if (multiFieldBatchPutCallback instanceof MultiFieldBatchPutDetailsCallback) {
+                    MultiFieldDetailsResult detailsResult = null;
+                    try {
+                        detailsResult = JSON.parseObject(responseContent, MultiFieldDetailsResult.class);
+                    } catch (JSONException jex) {
+                        // not all the 400 error has detailed information
+                        LOGGER.warn("failed to deserialize {} into MultiFieldDetailsResult", responseContent);
+                    }
+                    ((MultiFieldBatchPutDetailsCallback) multiFieldBatchPutCallback).failed(this.address, pointList, bdex, detailsResult);
+                    return;
+                }
+            }
             multiFieldBatchPutCallback.failed(this.address, pointList, ex);
         }
     }

--- a/src/main/java/com/aliyun/hitsdb/client/exception/http/HttpServerBadRequestException.java
+++ b/src/main/java/com/aliyun/hitsdb/client/exception/http/HttpServerBadRequestException.java
@@ -1,0 +1,11 @@
+package com.aliyun.hitsdb.client.exception.http;
+
+import com.aliyun.hitsdb.client.http.response.ResultResponse;
+
+// originally, the 400 was returned with HttpServerNotSupportException
+// as a result, let HttpServerBadRequestException extend from HttpServerNotSupportException for the backward compatibility
+public class HttpServerBadRequestException extends HttpServerNotSupportException {
+    public HttpServerBadRequestException(ResultResponse result) {
+        super(result);
+    }
+}

--- a/src/main/java/com/aliyun/hitsdb/client/exception/http/HttpUnknowStatusException.java
+++ b/src/main/java/com/aliyun/hitsdb/client/exception/http/HttpUnknowStatusException.java
@@ -26,6 +26,10 @@ public class HttpUnknowStatusException extends RuntimeException {
         return status;
     }
 
+    /**
+     * get the response content despite the name "message" of variable
+     * @return the response content in string
+     */
     public String getMessage() {
         return message;
     }

--- a/src/main/java/com/aliyun/hitsdb/client/http/response/HttpStatus.java
+++ b/src/main/java/com/aliyun/hitsdb/client/http/response/HttpStatus.java
@@ -3,6 +3,7 @@ package com.aliyun.hitsdb.client.http.response;
 public enum HttpStatus {
     ServerSuccess,
     ServerSuccessNoContent,
+    ServerBadRequest,
     ServerNotSupport,
     ServerError,
     ServerUnauthorized,

--- a/src/main/java/com/aliyun/hitsdb/client/http/response/ResultResponse.java
+++ b/src/main/java/com/aliyun/hitsdb/client/http/response/ResultResponse.java
@@ -29,7 +29,9 @@ public class ResultResponse {
             } else {
                 this.httpStatus = HttpStatus.ServerSuccess;
             }
-        } else if (statusCode >= 400 && statusCode < 500) {
+        } else if (statusCode == 400) {
+            this.httpStatus = HttpStatus.ServerBadRequest;
+        } else if (statusCode > 400 && statusCode < 500) {
             if (statusCode == 401) {
                 this.httpStatus = HttpStatus.ServerUnauthorized;
             } else {

--- a/src/main/java/com/aliyun/hitsdb/client/value/response/batch/DetailsResult.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/response/batch/DetailsResult.java
@@ -4,19 +4,13 @@ import java.util.List;
 
 import com.aliyun.hitsdb.client.value.Result;
 
-public class DetailsResult extends Result {
+public class DetailsResult extends SummaryResult {
     private List<ErrorPoint> errors;
-    private int failed;
-    private int success;
 
-    public DetailsResult() {
-        super();
-    }
+    public DetailsResult() { super(); }
 
     public DetailsResult(int success, int failed, List<ErrorPoint> errors) {
-        super();
-        this.success = success;
-        this.failed = failed;
+        super(success, failed);
         this.errors = errors;
     }
 
@@ -24,24 +18,8 @@ public class DetailsResult extends Result {
         return errors;
     }
 
-    public int getFailed() {
-        return failed;
-    }
-
-    public int getSuccess() {
-        return success;
-    }
-
     public void setErrors(List<ErrorPoint> errors) {
         this.errors = errors;
-    }
-
-    public void setFailed(int failed) {
-        this.failed = failed;
-    }
-
-    public void setSuccess(int success) {
-        this.success = success;
     }
 
 }

--- a/src/main/java/com/aliyun/hitsdb/client/value/response/batch/MultiFieldDetailsResult.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/response/batch/MultiFieldDetailsResult.java
@@ -4,19 +4,15 @@ import com.aliyun.hitsdb.client.value.Result;
 
 import java.util.List;
 
-public class MultiFieldDetailsResult extends Result {
+public class MultiFieldDetailsResult extends SummaryResult {
     private List<MultiFieldErrorPoint> errors;
-    private int failed;
-    private int success;
 
     public MultiFieldDetailsResult() {
         super();
     }
 
     public MultiFieldDetailsResult(int success, int failed, List<MultiFieldErrorPoint> errors) {
-        super();
-        this.success = success;
-        this.failed = failed;
+        super(success, failed);
         this.errors = errors;
     }
 
@@ -24,24 +20,7 @@ public class MultiFieldDetailsResult extends Result {
         return errors;
     }
 
-    public int getFailed() {
-        return failed;
-    }
-
-    public int getSuccess() {
-        return success;
-    }
-
     public void setErrors(List<MultiFieldErrorPoint> errors) {
         this.errors = errors;
     }
-
-    public void setFailed(int failed) {
-        this.failed = failed;
-    }
-
-    public void setSuccess(int success) {
-        this.success = success;
-    }
-
 }

--- a/src/test/java/com/aliyun/hitsdb/client/value/TSDBDataTypeTest.java
+++ b/src/test/java/com/aliyun/hitsdb/client/value/TSDBDataTypeTest.java
@@ -24,7 +24,13 @@ public class TSDBDataTypeTest {
 
     @Before
     public void setup() {
-        JSON.DEFAULT_PARSER_FEATURE &= ~Feature.UseBigDecimal.getMask();
+        try {
+            // call the static constructor of TSDBClient by force
+            // so that the setting of the default double deserialization behavior of fastjson would be applied
+            Class.forName("com.aliyun.hitsdb.client.TSDBClient");
+        } catch (Exception ex) {
+            System.err.println(ex.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/com/aliyun/hitsdb/client/value/response/TestBatchPutHttpResponseCallback.java
+++ b/src/test/java/com/aliyun/hitsdb/client/value/response/TestBatchPutHttpResponseCallback.java
@@ -1,0 +1,337 @@
+package com.aliyun.hitsdb.client.value.response;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.aliyun.hitsdb.client.TSDBConfig;
+import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
+import com.aliyun.hitsdb.client.callback.BatchPutDetailsCallback;
+import com.aliyun.hitsdb.client.callback.BatchPutSummaryCallback;
+import com.aliyun.hitsdb.client.callback.http.BatchPutHttpResponseCallback;
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
+import com.aliyun.hitsdb.client.exception.http.HttpServerNotSupportException;
+import com.aliyun.hitsdb.client.http.HttpClient;
+import com.aliyun.hitsdb.client.http.response.ResultResponse;
+import com.aliyun.hitsdb.client.value.request.Point;
+import com.aliyun.hitsdb.client.value.response.batch.DetailsResult;
+import com.aliyun.hitsdb.client.value.response.batch.ErrorPoint;
+import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BatchPutHttpResponseCallback.class, HttpClient.class})
+public class TestBatchPutHttpResponseCallback {
+    @BeforeClass
+    public static void setup() {
+        try {
+            // call the static constructor of TSDBClient by force
+            // so that the setting of the default double deserialization behavior of fastjson would be applied
+            Class.forName("com.aliyun.hitsdb.client.TSDBClient");
+        } catch (Exception ex) {
+            System.err.println(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testFailedWithResponse() throws Exception {
+        // bad request with BatchPutDetailsCallback
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<Point> points, DetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, DetailsResult result) {
+                    Assert.assertTrue(ex == bdex);
+                    Assert.assertEquals(ex.getStatus(), 400);
+
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+
+                    Assert.assertEquals(jsonErrors.size(), result.getErrors().size());
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with BatchPutDetailsCallback
+        {
+            String content = "{\"failed\":3,\"success\":0,\"errors\":[{\"error\":\"Invalid timestamp\",\"datapoint\":{\"value\":0.35,\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":0}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<Point> points, DetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, DetailsResult result) {
+                    Assert.assertTrue(ex == bdex);
+                    Assert.assertEquals(ex.getStatus(), 400);
+
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+
+                    Assert.assertEquals(jsonErrors.size(), result.getErrors().size());
+
+                    ErrorPoint ep = result.getErrors().get(0);
+                    Assert.assertNotNull(ep);
+                    Assert.assertTrue("Invalid timestamp".equals(ep.getError()));
+
+                    Assert.assertEquals(0.35, (Double)ep.getDatapoint().getValue(), 0.001);
+                    Assert.assertEquals(0L, (long)ep.getDatapoint().getTimestamp());
+                    Assert.assertTrue("basetime.metric".equals(ep.getDatapoint().getMetric()));
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with BatchPutDetailsCallback
+        // backward compatibility
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<Point> points, DetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request without details response
+        // backward compatibility
+        {
+            String content = "Invalid timestamp";
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<Point> points, DetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+
+        // bad request without details response
+        {
+            String content = "Invalid timestamp";
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<Point> points, DetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, DetailsResult result) {
+                    Assert.assertNull(result);
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+
+        // bad request with BatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            HttpServerBadRequestException ex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<Point> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.fail("failed() whithout summary called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), ex);
+        }
+
+        // bad request with BatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<Point> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.fail("failed() whithout summary called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with BatchPutSummaryCallback
+        // backward compatibility
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<Point> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with BatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerNotSupportException bdex = new HttpServerNotSupportException(response);
+
+            AbstractBatchPutCallback cb = new BatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<Point> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<Point> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+
+                @Override
+                public void failed(String address, List<Point> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.fail("failed() whith summary called");
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+    }
+
+    private BatchPutHttpResponseCallback createMultiFieldBatchPutHttpResponseCallback(AbstractBatchPutCallback<?> batchPutCallback) {
+        TSDBConfig config = TSDBConfig.address("127.0.0.1", 3002).config();
+        HttpClient client = mock(HttpClient.class);
+
+        BatchPutHttpResponseCallback callback = new BatchPutHttpResponseCallback("127.0.0.1", client,
+                batchPutCallback, Collections.EMPTY_LIST,  config, 3);
+        return callback;
+    }
+
+    private void callFailedWithResponse(BatchPutHttpResponseCallback callback, Exception ex) throws Exception {
+        Whitebox.invokeMethod(callback, "failedWithResponse", ex);
+    }
+}

--- a/src/test/java/com/aliyun/hitsdb/client/value/response/TestMultiFieldBatchPutHttpResponseCallback.java
+++ b/src/test/java/com/aliyun/hitsdb/client/value/response/TestMultiFieldBatchPutHttpResponseCallback.java
@@ -1,0 +1,348 @@
+package com.aliyun.hitsdb.client.value.response;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.aliyun.hitsdb.client.TSDBConfig;
+import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
+import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutDetailsCallback;
+import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutSummaryCallback;
+import com.aliyun.hitsdb.client.callback.http.MultiFieldBatchPutHttpResponseCallback;
+import com.aliyun.hitsdb.client.exception.http.HttpServerBadRequestException;
+import com.aliyun.hitsdb.client.exception.http.HttpServerNotSupportException;
+import com.aliyun.hitsdb.client.http.HttpClient;
+import com.aliyun.hitsdb.client.http.response.ResultResponse;
+import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
+import com.aliyun.hitsdb.client.value.response.batch.MultiFieldDetailsResult;
+import com.aliyun.hitsdb.client.value.response.batch.MultiFieldErrorPoint;
+import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
+import org.junit.Assert;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MultiFieldBatchPutHttpResponseCallback.class, HttpClient.class})
+public class TestMultiFieldBatchPutHttpResponseCallback {
+
+    @BeforeClass
+    public static void setup() {
+        try {
+            // call the static constructor of TSDBClient by force
+            // so that the setting of the default double deserialization behavior of fastjson would be applied
+            Class.forName("com.aliyun.hitsdb.client.TSDBClient");
+        } catch (Exception ex) {
+            System.err.println(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testFailedWithResponse() throws Exception {
+        // bad request with MultiFieldBatchPutDetailsCallback
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, MultiFieldDetailsResult result) {
+                    Assert.assertTrue(ex == bdex);
+                    Assert.assertEquals(ex.getStatus(), 400);
+
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+
+                    Assert.assertEquals(jsonErrors.size(), result.getErrors().size());
+
+                    for (MultiFieldErrorPoint ep : result.getErrors()) {
+                        Assert.assertNotNull(ep.getDatapoint());
+                        Assert.assertEquals(3, ep.getDatapoint().getFields().size());
+                    }
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with MultiFieldBatchPutDetailsCallback
+        {
+            String content = "{\"failed\":3,\"success\":0,\"errors\":[{\"error\":\"Invalid timestamp\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":0}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, MultiFieldDetailsResult result) {
+                    Assert.assertTrue(ex == bdex);
+                    Assert.assertEquals(ex.getStatus(), 400);
+
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+
+                    Assert.assertEquals(jsonErrors.size(), result.getErrors().size());
+
+                    MultiFieldErrorPoint ep = result.getErrors().get(0);
+                    Assert.assertNotNull(ep);
+                    Assert.assertTrue("Invalid timestamp".equals(ep.getError()));
+                    Map<String, Object> fields = ep.getDatapoint().getFields();
+                    Assert.assertEquals(0.35, (Double)fields.get("hum"), 0.001);
+                    Assert.assertEquals(123.5, (Double)fields.get("temp"), 0.001);
+                    Assert.assertTrue("hello, eee".equals(fields.get("label")));
+                    Assert.assertEquals(0L, (long)ep.getDatapoint().getTimestamp());
+                    Assert.assertTrue("basetime.metric".equals(ep.getDatapoint().getMetric()));
+
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with MultiFieldBatchPutDetailsCallback
+        // backward compatibility
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request without details response
+        // backward compatibility
+        {
+            String content = "Invalid timestamp";
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+
+        // bad request without details response
+        {
+            String content = "Invalid timestamp";
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutDetailsCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.fail("failed() whithout details called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, MultiFieldDetailsResult result) {
+                    Assert.assertNull(result);
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+
+        // bad request with MultiFieldBatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3,\"errors\":[{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.34,\"label\":\"hello, ddd\",\"temp\":123.45},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961600}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}},{\"error\":\"Partial write failed. cause: org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException\",\"datapoint\":{\"fields\":{\"hum\":0.35,\"label\":\"hello, eee\",\"temp\":123.50},\"metric\":\"basetime.metric\",\"tags\":{\"_id\":\"X00001\"},\"timestamp\":1607961630}}]}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            HttpServerBadRequestException ex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.fail("failed() whithout summary called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), ex);
+        }
+
+        // bad request with MultiFieldBatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.fail("failed() whithout summary called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.assertEquals(jsonContent.getLong("success").longValue(), result.getSuccess());
+                    Assert.assertEquals(jsonContent.getLong("failed").longValue(), result.getFailed());
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with MultiFieldBatchPutSummaryCallback
+        // backward compatibility
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerBadRequestException bdex = new HttpServerBadRequestException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+
+        // bad request with MultiFieldBatchPutSummaryCallback
+        {
+            String content = "{\"success\":6,\"failed\":3}";
+            final JSONObject jsonContent = JSON.parseObject(content);
+            final JSONArray jsonErrors = jsonContent.getJSONArray("errors");
+
+
+            ResultResponse response = new ResultResponse(400, content);
+            final HttpServerNotSupportException bdex = new HttpServerNotSupportException(response);
+
+            AbstractMultiFieldBatchPutCallback cb = new MultiFieldBatchPutSummaryCallback() {
+                @Override
+                public void response(String address, List<MultiFieldPoint> points, SummaryResult result) {
+                    Assert.fail("response() called");
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> input, Exception ex) {
+                    Assert.assertTrue(ex == bdex);
+                }
+
+                @Override
+                public void failed(String address, List<MultiFieldPoint> points, HttpServerBadRequestException ex, SummaryResult result) {
+                    Assert.fail("failed() whith summary called");
+                }
+            };
+
+            callFailedWithResponse(createMultiFieldBatchPutHttpResponseCallback(cb), bdex);
+        }
+    }
+
+    private MultiFieldBatchPutHttpResponseCallback createMultiFieldBatchPutHttpResponseCallback(AbstractMultiFieldBatchPutCallback<?> multiFieldBatchPutCallback) {
+        TSDBConfig config = TSDBConfig.address("127.0.0.1", 3002).config();
+        HttpClient client = mock(HttpClient.class);
+
+        MultiFieldBatchPutHttpResponseCallback callback = new MultiFieldBatchPutHttpResponseCallback("127.0.0.1", client,
+                multiFieldBatchPutCallback, Collections.EMPTY_LIST,  config, 3);
+        return callback;
+    }
+
+    private void callFailedWithResponse(MultiFieldBatchPutHttpResponseCallback callback, Exception ex) throws Exception {
+        Whitebox.invokeMethod(callback, "failedWithResponse", ex);
+    }
+}


### PR DESCRIPTION
add the support of summary & details for the callback of bad request because we cannot get the summary / detailed info even if the TSDB server returned them