### PR TITLE
Add lastResultReverseEnable config

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/AbstractConfig.java
+++ b/src/main/java/com/aliyun/hitsdb/client/AbstractConfig.java
@@ -145,6 +145,8 @@ public abstract class AbstractConfig implements Config {
 
     protected boolean deduplicationEnable;
 
+    protected boolean lastResultReverseEnable;
+
     @Override
     public boolean isSslEnable() {
         return sslEnable;
@@ -320,6 +322,11 @@ public abstract class AbstractConfig implements Config {
         return this.deduplicationEnable;
     }
 
+    @Override
+    public boolean isLastResultReverseEnable() {
+        return this.lastResultReverseEnable;
+    }
+
     protected void copy(AbstractConfig config, String host, int port) {
         config.host = host;
         config.port = port;
@@ -350,5 +357,6 @@ public abstract class AbstractConfig implements Config {
             config.putRequestLimit = this.httpConnectionPool;
         }
         config.deduplicationEnable = this.deduplicationEnable;
+        config.lastResultReverseEnable = this.lastResultReverseEnable;
     }
 }

--- a/src/main/java/com/aliyun/hitsdb/client/Config.java
+++ b/src/main/java/com/aliyun/hitsdb/client/Config.java
@@ -86,4 +86,6 @@ public interface Config {
     HAPolicy getHAPolicy();
 
     boolean isDeduplicationEnable();
+
+    boolean isLastResultReverseEnable();
 }

--- a/src/main/java/com/aliyun/hitsdb/client/TSDBConfig.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDBConfig.java
@@ -80,6 +80,8 @@ public class TSDBConfig extends AbstractConfig {
 
         private boolean deduplicationEnable = false;
 
+        private boolean lastResultReverseEnable = false;
+
         public Builder(String host) {
             this.host = host;
             this.uniqueHost.add(host);
@@ -304,6 +306,11 @@ public class TSDBConfig extends AbstractConfig {
             return this;
         }
 
+        public Builder lastResultReverseEnable () {
+            this.lastResultReverseEnable = true;
+            return this;
+        }
+
         public  TSDBConfig config() {
             if (multiFieldBatchPutConsumerThreadCount <= 0 && batchPutConsumerThreadCount <= 0) {
                 throw new IllegalArgumentException("At least one of multiFieldBatchPutConsumerThreadCount and batchPutConsumerThreadCount is greater than 0");
@@ -367,6 +374,7 @@ public class TSDBConfig extends AbstractConfig {
             }
             config.haPolicy = this.haPolicy;
             config.deduplicationEnable = this.deduplicationEnable;
+            config.lastResultReverseEnable = this.lastResultReverseEnable;
 
             return config;
         }

--- a/src/test/java/com/aliyun/hitsdb/client/TestLastResultTimestampReverse.java
+++ b/src/test/java/com/aliyun/hitsdb/client/TestLastResultTimestampReverse.java
@@ -1,0 +1,79 @@
+package com.aliyun.hitsdb.client;
+
+import com.aliyun.hitsdb.client.value.response.LastDataValue;
+import com.aliyun.hitsdb.client.value.response.MultiFieldQueryLastResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cuiyuan
+ * @date 2021/3/24 12:21 下午
+ */
+public class TestLastResultTimestampReverse {
+
+    @Test
+    public void testMultiValueTimestampReverse() {
+        MultiFieldQueryLastResult multiFieldQueryLastResult = new MultiFieldQueryLastResult();
+
+        List<Object> t1 = new ArrayList<Object>();
+        List<Object> t2 = new ArrayList<Object>();
+        List<Object> t3 = new ArrayList<Object>();
+        t1.add(1L);
+        t2.add(2L);
+        t3.add(3L);
+
+        List<List<Object>> values = new ArrayList<List<Object>>();
+        values.add(t1);
+        values.add(t2);
+        values.add(t3);
+
+        multiFieldQueryLastResult.setValues(values);
+
+        long timestamp = 1;
+        for (List<Object> value :multiFieldQueryLastResult.getValues()) {
+            Assert.assertEquals(timestamp, value.get(0));
+            timestamp++;
+        }
+
+        TSDBClient.reverseMultiValueTimestamp(multiFieldQueryLastResult);
+
+        Assert.assertEquals(3, multiFieldQueryLastResult.getValues().size());
+        timestamp = 3;
+        for (List<Object> value :multiFieldQueryLastResult.getValues()) {
+            Assert.assertEquals(timestamp, value.get(0));
+            timestamp--;
+        }
+    }
+
+    @Test
+    public void testSingleValueTimestampReverse() {
+        LastDataValue lastDataValue = new LastDataValue();
+        LinkedHashMap<Long, Object> dps = new LinkedHashMap<Long, Object>();
+        dps.put(1L, 1L);
+        dps.put(2L, 2L);
+        dps.put(3L, 3L);
+        lastDataValue.setDps(dps);
+        long timestamp = 1;
+        for (Map.Entry<Long, Object> longObjectEntry : lastDataValue.getDps().entrySet()) {
+            Assert.assertEquals(timestamp, longObjectEntry.getKey().longValue());
+            Assert.assertEquals(timestamp, longObjectEntry.getValue());
+            timestamp++;
+        }
+
+        TSDBClient.reverseSingleValueTimestamp(lastDataValue);
+
+        //after reverse
+        Assert.assertEquals(3, lastDataValue.getDps().entrySet().size());
+        timestamp = 3;
+        for (Map.Entry<Long, Object> longObjectEntry : lastDataValue.getDps().entrySet()) {
+            Assert.assertEquals(timestamp, longObjectEntry.getKey().longValue());
+            Assert.assertEquals(timestamp, longObjectEntry.getValue());
+            timestamp--;
+        }
+    }
+}


### PR DESCRIPTION
默认配置last查询结果中时间戳正序返回，如果需要启用按时间戳逆序返回, 需要在配置中开启lastResultReverseEnable()

```java
                TSDBConfig config = TSDBConfig
				.address("127.0.0.1", 8242)
				.lastResultReverseEnable()
				.config();

		TSDB tsdb = TSDBClientFactory.connect(config);

```