### PR TITLE
support set header for client & add fatal list for Lindorm TSDB

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/TSDBClient.java
@@ -49,8 +49,8 @@ public class TSDBClient implements TSDB {
     private final Consumer consumer;
     private final HttpResponseCallbackFactory httpResponseCallbackFactory;
     private final boolean httpCompress;
-    private final HttpClient httpclient;
-    private final HttpClient secondaryClient;
+    protected final HttpClient httpclient;
+    protected final HttpClient secondaryClient;
     private RateLimiter rateLimiter;
     private final Config config;
     private static Field queryDeleteField;

--- a/src/main/java/com/aliyun/hitsdb/client/http/HttpClient.java
+++ b/src/main/java/com/aliyun/hitsdb/client/http/HttpClient.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
@@ -15,7 +16,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 
 import com.aliyun.hitsdb.client.Config;
-import com.aliyun.hitsdb.client.TSDBConfig;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
@@ -44,6 +44,7 @@ public class HttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
     public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
     private static final String version = "0.1";
+    private Map<String, String> headerParamsMap;
 
     private String host;
     private int port;
@@ -124,6 +125,14 @@ public class HttpClient {
         this.certContent = config.getCertContent();
     }
 
+    public void setHeaderParamsMap(Map<String, String> headerParamsMap) {
+        this.headerParamsMap = headerParamsMap;
+    }
+
+    public Map<String, String> getHeaderParamsMap() {
+        return this.headerParamsMap;
+    }
+
     public void close() throws IOException {
         this.close(false);
     }
@@ -178,6 +187,15 @@ public class HttpClient {
             } else {
                 request.addHeader("Accept-Encoding", "gzip, deflate");
                 request.setEntity(generateGZIPCompressEntity(json));
+            }
+        }
+
+        if (this.headerParamsMap != null && !this.headerParamsMap.isEmpty()) {
+            Iterator paramItr = this.headerParamsMap.entrySet().iterator();
+
+            while(paramItr.hasNext()) {
+                Entry<String, String> entry = (Entry)paramItr.next();
+                request.setHeader((String)entry.getKey(), (String)entry.getValue());
             }
         }
 
@@ -309,6 +327,15 @@ public class HttpClient {
             } else {
                 request.addHeader("Accept-Encoding", "gzip, deflate");
                 request.setEntity(generateGZIPCompressEntity(json));
+            }
+        }
+
+        if (this.headerParamsMap != null && !this.headerParamsMap.isEmpty()) {
+            Iterator paramItr = this.headerParamsMap.entrySet().iterator();
+
+            while(paramItr.hasNext()) {
+                Entry<String, String> entry = (Entry)paramItr.next();
+                request.setHeader((String)entry.getKey(), (String)entry.getValue());
             }
         }
 

--- a/src/main/java/com/aliyun/hitsdb/client/value/response/batch/DetailsResult.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/response/batch/DetailsResult.java
@@ -3,21 +3,35 @@ package com.aliyun.hitsdb.client.value.response.batch;
 import java.util.List;
 
 import com.aliyun.hitsdb.client.value.Result;
+import com.aliyun.hitsdb.client.value.request.Point;
 
 public class DetailsResult extends Result {
     private List<ErrorPoint> errors;
     private int failed;
     private int success;
+    /**
+     * fatal is only used for Lindorm TSDB
+     */
+    private List<Point> fatal;
 
     public DetailsResult() {
         super();
     }
 
-    public DetailsResult(int success, int failed, List<ErrorPoint> errors) {
+    public DetailsResult(int success, int failed, List<ErrorPoint> errors, List<Point> fatal) {
         super();
         this.success = success;
         this.failed = failed;
         this.errors = errors;
+        this.fatal = fatal;
+    }
+
+    public List<Point> getFatal() {
+        return fatal;
+    }
+
+    public void setFatal(List<Point> fatal) {
+        this.fatal = fatal;
     }
 
     public List<ErrorPoint> getErrors() {

--- a/src/main/java/com/aliyun/hitsdb/client/value/response/batch/MultiFieldDetailsResult.java
+++ b/src/main/java/com/aliyun/hitsdb/client/value/response/batch/MultiFieldDetailsResult.java
@@ -1,6 +1,7 @@
 package com.aliyun.hitsdb.client.value.response.batch;
 
 import com.aliyun.hitsdb.client.value.Result;
+import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
 
 import java.util.List;
 
@@ -8,16 +9,29 @@ public class MultiFieldDetailsResult extends Result {
     private List<MultiFieldErrorPoint> errors;
     private int failed;
     private int success;
+    /**
+     * fatal is only used for Lindorm TSDB
+     */
+    private List<MultiFieldPoint> fatal;
 
     public MultiFieldDetailsResult() {
         super();
     }
 
-    public MultiFieldDetailsResult(int success, int failed, List<MultiFieldErrorPoint> errors) {
+    public MultiFieldDetailsResult(int success, int failed, List<MultiFieldErrorPoint> errors, List<MultiFieldPoint> fatal) {
         super();
         this.success = success;
         this.failed = failed;
         this.errors = errors;
+        this.fatal = fatal;
+    }
+
+    public List<MultiFieldPoint> getFatal() {
+        return fatal;
+    }
+
+    public void setFatal(List<MultiFieldPoint> fatal) {
+        this.fatal = fatal;
     }
 
     public List<MultiFieldErrorPoint> getErrors() {


### PR DESCRIPTION
* Lindorm TSDB测试需要设置header（租户信息），目前是单独发snapshot版本用于测试，相关功能合入主线就不用未来每次测试SDK相关功能都打一个snapshot
* Lindorm TSDB支持返回fatal字段，但是目前SDK里对于400，500错误是直接抛异常，所以实际200的解析不会带出该字段