### PR TITLE
feat: ha swtich [failover]

### DIFF
--- a/src/main/java/com/aliyun/hitsdb/client/Config.java
+++ b/src/main/java/com/aliyun/hitsdb/client/Config.java
@@ -2,14 +2,9 @@ package com.aliyun.hitsdb.client;
 
 import com.aliyun.hitsdb.client.callback.AbstractBatchPutCallback;
 import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
-import com.aliyun.hitsdb.client.exception.http.HttpClientInitException;
 import com.aliyun.hitsdb.client.http.Host;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public interface Config {
     String BASICTYPE = "Basic";    // it should be "Basic" according to RFC 2617

--- a/src/main/java/com/aliyun/hitsdb/client/HAPolicy.java
+++ b/src/main/java/com/aliyun/hitsdb/client/HAPolicy.java
@@ -2,19 +2,38 @@ package com.aliyun.hitsdb.client;
 
 import com.aliyun.hitsdb.client.http.HttpClient;
 import com.aliyun.hitsdb.client.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author johnnyzou
  * @date 2020/02/07
  */
 public class HAPolicy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HAPolicy.class);
+
     private Pair<String, Integer> secondaryCluster;
-    private RetryRule retryRule = RetryRule.SecondaryPreferred;
-    private int queryRetryTimes = 0;
+    private RetryRule queryRetryRule = RetryRule.Primary;
+    private RetryRule writeRetryRule = RetryRule.Primary;
+    private int queryRetryTimes;
+    private int writeRetryTimes;
+    private int checkCount;
+    private int intervalSeconds;
+    private int totalRetryTimes;
+    private boolean haSwitch;
+    private boolean isReady;
+    /* primaryClient has switched to secondaryCluster */
+    private boolean stateChanged;
+    private HttpClient primaryClient;
+    private HttpClient secondaryClient;
+    ReentrantLock lock = new ReentrantLock();
     /*
-     * TODO: support queryRetryInterval
+     * TODO: support RetryInterval
      */
     private long queryRetryInterval = 0;
+    private long writeRetryInterval = 0;
 
     public enum RetryRule {
         /*
@@ -48,16 +67,49 @@ public class HAPolicy {
             policy.secondaryCluster = new Pair<String, Integer>(secondaryHost, secondaryPort);
         }
 
+        @Deprecated
         public Builder setRetryRule(RetryRule rule) {
-            policy.retryRule = rule;
+            policy.queryRetryRule = rule;
             return this;
         }
 
+        @Deprecated
         public Builder setRetryTimes(int retryTimes) {
             if (retryTimes < 0) {
                 throw new IllegalArgumentException("retryTimes must greater or equal than 0");
             }
             policy.queryRetryTimes = retryTimes;
+            return this;
+        }
+
+        public Builder setQueryRetryRule(RetryRule rule, int retryTimes) {
+            policy.queryRetryRule = rule;
+            if (retryTimes < 0) {
+                throw new IllegalArgumentException("retryTimes must greater or equal than 0");
+            }
+            policy.queryRetryTimes = retryTimes;
+            return this;
+        }
+
+        public Builder setWriteRetryRule(RetryRule rule, int retryTimes) {
+            policy.writeRetryRule = rule;
+            if (retryTimes < 0) {
+                throw new IllegalArgumentException("retryTimes must greater or equal than 0");
+            }
+            policy.writeRetryTimes = retryTimes;
+            return this;
+        }
+
+        public Builder setFailoverRule(int checkCount, int intervalSeconds) {
+            if (checkCount < 1) {
+                throw new IllegalArgumentException("checkCount must greater or equal than 1");
+            }
+            if (intervalSeconds < 1) {
+                throw new IllegalArgumentException("intervalSeconds must greater or equal than 1 second");
+            }
+            policy.haSwitch = true;
+            policy.checkCount = checkCount;
+            policy.intervalSeconds = intervalSeconds;
             return this;
         }
 
@@ -74,35 +126,162 @@ public class HAPolicy {
         return secondaryCluster.getValue();
     }
 
+    public void setSecondaryCluster(String secondaryHost, int secondaryPort) {
+        this.secondaryCluster = new Pair<String, Integer>(secondaryHost, secondaryPort);
+    }
+
+    @Deprecated
     public RetryRule getRetryRule() {
-        return retryRule;
+        return queryRetryRule;
+    }
+
+    public RetryRule getQueryRetryRule() {
+        return queryRetryRule;
+    }
+
+    public boolean isQueryPrimaryFirstRule() {
+        return queryRetryRule.equals(RetryRule.Primary) || queryRetryRule.equals(RetryRule.PrimaryPreferred);
     }
 
     public int getQueryRetryTimes() {
         return queryRetryTimes;
     }
 
+    // current not used
     public long getQueryRetryInterval() {
         return queryRetryInterval;
     }
 
-    public static class QueryContext {
+    public RetryRule getWriteRetryRule() {
+        return writeRetryRule;
+    }
+
+    public boolean isWritePrimaryFirstRule() {
+        return writeRetryRule.equals(RetryRule.Primary) || writeRetryRule.equals(RetryRule.PrimaryPreferred);
+    }
+
+    public int getWriteRetryTimes() {
+        return writeRetryTimes;
+    }
+
+    // current not used
+    public long getWriteRetryInterval() {
+        return writeRetryInterval;
+    }
+
+    public boolean isHaSwitch() {
+        return haSwitch;
+    }
+
+    public int getCheckCount() {
+        return checkCount;
+    }
+
+    public int getIntervalSeconds() {
+        return intervalSeconds;
+    }
+
+    public void setClusterClient(HttpClient primaryClient, HttpClient secondaryClient) {
+        this.primaryClient = primaryClient;
+        this.secondaryClient = secondaryClient;
+        isReady = true;
+    }
+
+    protected void addTotalRetryTimes() {
+        totalRetryTimes++;
+        if (haSwitch && totalRetryTimes > checkCount) {
+            lock.lock();
+            try {
+                if (totalRetryTimes > checkCount) {
+                    HttpClient temp = primaryClient;
+                    primaryClient = secondaryClient;
+                    secondaryClient = temp;
+                    resetTotalRetryTimes();
+                    LOGGER.error("failed too much, primaryClient and secondaryClient has changed.");
+                    checkStateChanged();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    public void resetClusterClient() {
+        if (stateChanged) {
+            lock.lock();
+            try {
+                checkStateChanged();
+                if (stateChanged == true) {
+                    HttpClient temp = primaryClient;
+                    primaryClient = secondaryClient;
+                    secondaryClient = temp;
+                    LOGGER.info("cluster client has reset, current main cluster : {}:{}", primaryClient.getHost(), primaryClient.getPort());
+                    stateChanged = false;
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    public void checkStateChanged() {
+        if (primaryClient.getHost() == secondaryCluster.getKey() && primaryClient.getPort() == secondaryCluster.getValue()) {
+            stateChanged = true;
+        } else {
+            stateChanged = false;
+        }
+    }
+
+    protected void resetTotalRetryTimes() {
+        totalRetryTimes = 0;
+    }
+
+    public HttpClient getPrimaryClient() {
+        if (haSwitch && totalRetryTimes > checkCount) {
+            return secondaryClient;
+        }
+        return primaryClient;
+    }
+
+    public HttpClient getSecondaryClient() {
+        if (haSwitch && totalRetryTimes > checkCount) {
+            return primaryClient;
+        }
+        return secondaryClient;
+    }
+
+    public QueryContext creatQueryContext() {
+        if (!isReady) {
+            throw new IllegalStateException("HA Policy is not ready");
+        }
+        return new QueryContext(this, getPrimaryClient(), getSecondaryClient());
+    }
+
+    public WriteContext creatWriteContext() {
+        if (!isReady) {
+            throw new IllegalStateException("HA Policy is not ready");
+        }
+        return new WriteContext(this, getPrimaryClient(), getSecondaryClient());
+    }
+
+
+    public class QueryContext {
         private HAPolicy haPolicy;
         private int retryTimes = 0;
         private HttpClient primaryClient;
         private HttpClient secondaryClient;
-        public QueryContext(HAPolicy haPolicy, HttpClient primaryClient, HttpClient secondaryClient) {
+        private QueryContext(HAPolicy haPolicy, HttpClient primaryClient, HttpClient secondaryClient) {
             this.haPolicy = haPolicy;
             this.primaryClient = primaryClient;
             this.secondaryClient = secondaryClient;
         }
 
         public boolean doQuery(){
-            if (haPolicy.getRetryRule() == RetryRule.Primary || haPolicy.getRetryRule() == RetryRule.Secondary) {
+            if (haPolicy.getQueryRetryRule() == RetryRule.Primary || haPolicy.getQueryRetryRule() == RetryRule.Secondary) {
                 if (retryTimes < haPolicy.getQueryRetryTimes()) {
                     return true;
                 }
-            } else if (haPolicy.getRetryRule() == RetryRule.PrimaryPreferred || haPolicy.getRetryRule() == RetryRule.SecondaryPreferred) {
+            } else if (haPolicy.getQueryRetryRule() == RetryRule.PrimaryPreferred || haPolicy.getQueryRetryRule() == RetryRule.SecondaryPreferred) {
                 if (retryTimes < haPolicy.getQueryRetryTimes() + 1) {
                     // retry on another client
                     return true;
@@ -113,10 +292,21 @@ public class HAPolicy {
 
         public void addRetryTimes() {
             retryTimes++;
+            if (haPolicy.isQueryPrimaryFirstRule()) {
+                HAPolicy.this.addTotalRetryTimes();
+            }
+        }
+
+        public void success(){
+            if (haPolicy.isQueryPrimaryFirstRule()) {
+                if (retryTimes <= haPolicy.getQueryRetryTimes()) {
+                    HAPolicy.this.resetTotalRetryTimes();
+                }
+            }
         }
 
         public HttpClient getClient() {
-            switch (haPolicy.getRetryRule()) {
+            switch (haPolicy.getQueryRetryRule()) {
                 case Primary:
                     return primaryClient;
                 case Secondary:
@@ -128,6 +318,69 @@ public class HAPolicy {
                     return primaryClient;
                 case PrimaryPreferred:
                     if (retryTimes <= haPolicy.getQueryRetryTimes()) {
+                        return primaryClient;
+                    }
+                    return secondaryClient;
+                default:
+                    throw new IllegalArgumentException("Unknown Retry Policy");
+            }
+        }
+    }
+
+
+    public class WriteContext {
+        private HAPolicy haPolicy;
+        private int retryTimes = 0;
+        private HttpClient primaryClient;
+        private HttpClient secondaryClient;
+        private WriteContext(HAPolicy haPolicy, HttpClient primaryClient, HttpClient secondaryClient) {
+            this.haPolicy = haPolicy;
+            this.primaryClient = primaryClient;
+            this.secondaryClient = secondaryClient;
+        }
+
+        public boolean doWrite(){
+            if (haPolicy.getWriteRetryRule() == RetryRule.Primary || haPolicy.getWriteRetryRule() == RetryRule.Secondary) {
+                if (retryTimes < haPolicy.getWriteRetryTimes()) {
+                    return true;
+                }
+            } else if (haPolicy.getWriteRetryRule() == RetryRule.PrimaryPreferred || haPolicy.getWriteRetryRule() == RetryRule.SecondaryPreferred) {
+                if (retryTimes < haPolicy.getWriteRetryTimes() + 1) {
+                    // retry on another client
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void addRetryTimes() {
+            retryTimes++;
+            if (haPolicy.isWritePrimaryFirstRule()) {
+                HAPolicy.this.addTotalRetryTimes();
+            }
+        }
+
+        public void success(){
+            if (haPolicy.isWritePrimaryFirstRule()) {
+                if (retryTimes <= haPolicy.getWriteRetryTimes()) {
+                    HAPolicy.this.resetTotalRetryTimes();
+                }
+            }
+        }
+
+        public HttpClient getClient() {
+            switch (haPolicy.getWriteRetryRule()) {
+                case Primary:
+                    return primaryClient;
+                case Secondary:
+                    return secondaryClient;
+                case SecondaryPreferred:
+                    if (retryTimes <= haPolicy.getWriteRetryTimes()) {
+                        return secondaryClient;
+                    }
+                    return primaryClient;
+                case PrimaryPreferred:
+                    if (retryTimes <= haPolicy.getWriteRetryTimes()) {
                         return primaryClient;
                     }
                     return secondaryClient;

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/AbstractPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/AbstractPutHttpResponseCallback.java
@@ -1,0 +1,88 @@
+package com.aliyun.hitsdb.client.callback.http;
+
+import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.HAPolicy;
+import com.aliyun.hitsdb.client.http.HttpAddressManager;
+import com.aliyun.hitsdb.client.http.HttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AbstractPutHttpResponseCallback implements FutureCallback<HttpResponse> {
+    static final Logger LOGGER = LoggerFactory.getLogger(AbstractPutHttpResponseCallback.class);
+    final int batchPutRetryTimes;
+    final boolean compress;
+    final HttpClient hitsdbHttpClient;
+    final Config config;
+    final String address;
+    final HAPolicy.WriteContext writeContext;
+
+    public AbstractPutHttpResponseCallback(String address, HttpClient httpclient, Config config, int batchPutRetryTimes, HAPolicy.WriteContext writeContext) {
+        this.address = address;
+        this.hitsdbHttpClient = httpclient;
+        this.batchPutRetryTimes = batchPutRetryTimes;
+        this.compress = config.isHttpCompress();
+        this.config = config;
+        this.writeContext = writeContext;
+    }
+
+    @Override
+    public void completed(HttpResponse httpResponse) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void failed(Exception ex) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+
+    @Override
+    public void cancelled() {
+        HttpClient httpClient = writeContext == null ? this.hitsdbHttpClient : writeContext.getClient();
+        httpClient.getSemaphoreManager().release(this.address);
+        LOGGER.info("the HttpAsyncClient has been cancelled");
+    }
+
+    protected String getNextAddress(HttpClient httpClient) {
+        HttpAddressManager httpAddressManager = httpClient.getHttpAddressManager();
+        String newAddress = httpAddressManager.getAddress();
+        return newAddress;
+    }
+
+    protected HttpClient getHttpClient(StringBuffer newAddressBuff) {
+        boolean acquire;
+        HttpClient httpClient;
+        int retryTimes = this.batchPutRetryTimes;
+        if (writeContext != null) {
+            if (writeContext.doWrite()) {
+                // TODO: add retry interval
+                writeContext.addRetryTimes();
+                httpClient = writeContext.getClient();
+                newAddressBuff.append(getNextAddress(httpClient));
+            } else {
+                httpClient = writeContext.getClient();
+                httpClient.getSemaphoreManager().release(address);
+                return null;
+            }
+        } else {
+            httpClient = this.hitsdbHttpClient;
+            while (true) {
+                newAddressBuff.append(getNextAddress(httpClient));
+                acquire = httpClient.getSemaphoreManager().acquire(newAddressBuff.toString());
+                retryTimes--;
+                if (acquire || retryTimes <= 0) {
+                    break;
+                }
+            }
+
+            if (retryTimes == 0) {
+                httpClient.getSemaphoreManager().release(address);
+                return null;
+            }
+        }
+        return httpClient;
+    }
+}

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/BatchPutHttpResponseCallback.java
@@ -4,7 +4,9 @@ import java.net.SocketTimeoutException;
 import java.util.List;
 
 import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.HAPolicy;
 import com.aliyun.hitsdb.client.callback.BatchPutIgnoreErrorsCallback;
+import com.aliyun.hitsdb.client.value.request.AbstractPoint;
 import com.aliyun.hitsdb.client.value.response.batch.IgnoreErrorsResult;
 import org.apache.http.HttpResponse;
 import org.apache.http.concurrent.FutureCallback;
@@ -31,27 +33,15 @@ import com.aliyun.hitsdb.client.value.request.Point;
 import com.aliyun.hitsdb.client.value.response.batch.DetailsResult;
 import com.aliyun.hitsdb.client.value.response.batch.SummaryResult;
 
-public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BatchPutHttpResponseCallback.class);
-
+public class BatchPutHttpResponseCallback extends AbstractPutHttpResponseCallback {
     private final AbstractBatchPutCallback<?> batchPutCallback;
-    private final List<Point> pointList;
-    private final int batchPutRetryTimes;
-    private final boolean compress;
-    private final HttpClient hitsdbHttpClient;
-    private final Config config;
-    private final String address;
+    final List<Point> pointList;
 
     public BatchPutHttpResponseCallback(String address, HttpClient httpclient, AbstractBatchPutCallback<?> batchPutCallback,
-                                        List<Point> pointList, Config config, int batchPutRetryTimes) {
-        super();
-        this.address = address;
-        this.hitsdbHttpClient = httpclient;
+                                        List<Point> pointList, Config config, int batchPutRetryTimes, HAPolicy.WriteContext writeContext) {
+        super(address, httpclient, config, batchPutRetryTimes, writeContext);
         this.batchPutCallback = batchPutCallback;
         this.pointList = pointList;
-        this.batchPutRetryTimes = batchPutRetryTimes;
-        this.compress = config.isHttpCompress();
-        this.config = config;
     }
 
     public AbstractBatchPutCallback<?> getLogicalBatchPutCallback() {
@@ -60,10 +50,11 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
 
     @Override
     public void completed(HttpResponse httpResponse) {
+        HttpClient httpClient = writeContext == null ? this.hitsdbHttpClient : writeContext.getClient();
         try {
             // 处理响应
             if (httpResponse.getStatusLine().getStatusCode() == org.apache.http.HttpStatus.SC_TEMPORARY_REDIRECT) {
-                this.hitsdbHttpClient.setSslEnable(true);
+                httpClient.setSslEnable(true);
                 if (errorRetry()) {
                     return;
                 }
@@ -73,6 +64,9 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
             switch (httpStatus) {
                 case ServerSuccess:
                 case ServerSuccessNoContent:
+                    if (writeContext != null) {
+                        writeContext.success();
+                    }
                     if (batchPutCallback == null) {
                         return;
                     }
@@ -107,13 +101,16 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
                     }
                 case ServerNotSupport: {
                     // 服务器返回4xx错误
+                    if (writeContext != null) {
+                        writeContext.success();
+                    }
                     HttpServerNotSupportException ex = new HttpServerNotSupportException(resultResponse);
                     this.failedWithResponse(ex);
                     return;
                 }
                 case ServerError: {
                     // 服务器返回5xx错误
-                    if (this.batchPutRetryTimes == 0) {
+                    if (this.batchPutRetryTimes == 0 && this.writeContext == null) {
                         HttpServerErrorException ex = new HttpServerErrorException(resultResponse);
                         this.failedWithResponse(ex);
                     } else {
@@ -133,7 +130,7 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
             }
         } finally {
             // 正常释放Semaphor
-            this.hitsdbHttpClient.getSemaphoreManager().release(address);
+            httpClient.getSemaphoreManager().release(address);
         }
     }
 
@@ -150,56 +147,45 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
         }
     }
 
-    private String getNextAddress() {
-        HttpAddressManager httpAddressManager = hitsdbHttpClient.getHttpAddressManager();
-        String newAddress = httpAddressManager.getAddress();
-        return newAddress;
-    }
-
     /**
      * execute the retry logic when writing failed
      * @return true if retry actually executed; false if retry limit reached
      */
-    private boolean errorRetry() {
-        String newAddress;
-        boolean acquire;
+    boolean errorRetry() {
+        StringBuffer newAddressBuff = new StringBuffer();
         int retryTimes = this.batchPutRetryTimes;
-        while (true) {
-            newAddress = getNextAddress();
-            acquire = this.hitsdbHttpClient.getSemaphoreManager().acquire(newAddress);
-            retryTimes--;
-            if (acquire || retryTimes <= 0) {
-                break;
-            }
-        }
-
-        if (retryTimes == 0) {
-            this.hitsdbHttpClient.getSemaphoreManager().release(address);
+        HttpClient httpClient = getHttpClient(newAddressBuff);
+        if (httpClient == null) {
             return false;
         }
+        String newAddress = newAddressBuff.toString();
 
         // retry!
         LOGGER.warn("retry put data!");
-        HttpResponseCallbackFactory httpResponseCallbackFactory = this.hitsdbHttpClient.getHttpResponseCallbackFactory();
+        HttpResponseCallbackFactory httpResponseCallbackFactory = httpClient.getHttpResponseCallbackFactory();
 
         FutureCallback<HttpResponse> retryCallback;
         if (batchPutCallback != null) {
-            retryCallback = httpResponseCallbackFactory.createBatchPutDataCallback(newAddress, this.batchPutCallback, this.pointList, this.config, retryTimes);
+            retryCallback = httpResponseCallbackFactory.createBatchPutDataCallback(newAddress,
+                    this.batchPutCallback, this.pointList, this.config, retryTimes, writeContext);
         } else {
-            retryCallback = httpResponseCallbackFactory.createNoLogicBatchPutHttpFutureCallback(newAddress, this.pointList, this.config, retryTimes);
+            retryCallback = httpResponseCallbackFactory.createNoLogicBatchPutHttpFutureCallback(newAddress,
+                    this.pointList, this.config, retryTimes, this.writeContext);
         }
 
         String jsonString = JSON.toJSONString(pointList);
-        this.hitsdbHttpClient.post(HttpAPI.PUT, jsonString, retryCallback);
+        httpClient.post(HttpAPI.PUT, jsonString, retryCallback);
         return true;
     }
 
+
     @Override
     public void failed(Exception ex) {
+        HttpClient httpClient = writeContext == null ? this.hitsdbHttpClient : writeContext.getClient();
         try {
             // 异常重试
             if (ex instanceof SocketTimeoutException) {
-                if (this.batchPutRetryTimes == 0) {
+                if (this.batchPutRetryTimes == 0 && this.writeContext == null) {
                     ex = new HttpClientSocketTimeoutException(ex);
                 } else {
                     if (errorRetry()) {
@@ -207,7 +193,7 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
                     }
                 }
             } else if (ex instanceof java.net.ConnectException) {
-                if (this.batchPutRetryTimes == 0) {
+                if (this.batchPutRetryTimes == 0 && this.writeContext == null) {
                     ex = new HttpClientConnectionRefusedException(this.address, ex);
                 } else {
                     if (errorRetry()) {
@@ -224,14 +210,7 @@ public class BatchPutHttpResponseCallback implements FutureCallback<HttpResponse
             }
         } finally {
             // 重试后释放semaphore许可
-            this.hitsdbHttpClient.getSemaphoreManager().release(address);
+            httpClient.getSemaphoreManager().release(address);
         }
     }
-
-    @Override
-    public void cancelled() {
-        this.hitsdbHttpClient.getSemaphoreManager().release(this.address);
-        LOGGER.info("the HttpAsyncClient has been cancelled");
-    }
-
 }

--- a/src/main/java/com/aliyun/hitsdb/client/callback/http/HttpResponseCallbackFactory.java
+++ b/src/main/java/com/aliyun/hitsdb/client/callback/http/HttpResponseCallbackFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.aliyun.hitsdb.client.Config;
+import com.aliyun.hitsdb.client.HAPolicy;
 import com.aliyun.hitsdb.client.callback.AbstractMultiFieldBatchPutCallback;
 import com.aliyun.hitsdb.client.util.Objects;
 import com.aliyun.hitsdb.client.value.request.MultiFieldPoint;
@@ -42,14 +43,16 @@ public class HttpResponseCallbackFactory {
             final AbstractBatchPutCallback<?> batchPutCallback,
             final List<Point> pointList,
             final Config config,
-            final int retryTimes) {
+            final int retryTimes,
+            final HAPolicy.WriteContext writeContext) {
         FutureCallback<HttpResponse> httpCallback = new BatchPutHttpResponseCallback(
                 address,
                 hitsdbHttpclient,
                 batchPutCallback,
                 pointList,
                 config,
-                retryTimes
+                retryTimes,
+                writeContext
         );
         return httpCallback;
     }
@@ -59,7 +62,8 @@ public class HttpResponseCallbackFactory {
             final String address,
             final List<Point> pointList,
             final Config config,
-            final int batchPutRetryTimes
+            final int batchPutRetryTimes,
+            final HAPolicy.WriteContext writeContext
     ) {
         FutureCallback<HttpResponse> httpCallback =
                 new BatchPutHttpResponseCallback(
@@ -68,7 +72,8 @@ public class HttpResponseCallbackFactory {
                         null,
                         pointList,
                         config,
-                        batchPutRetryTimes
+                        batchPutRetryTimes,
+                        writeContext
                 );
         return httpCallback;
     }
@@ -80,14 +85,16 @@ public class HttpResponseCallbackFactory {
             final AbstractMultiFieldBatchPutCallback<?> batchPutCallback,
             final List<MultiFieldPoint> pointList,
             final Config config,
-            final int retryTimes) {
+            final int retryTimes,
+            final HAPolicy.WriteContext writeContext) {
         FutureCallback<HttpResponse> httpCallback = new MultiFieldBatchPutHttpResponseCallback(
                 address,
                 hitsdbHttpclient,
                 batchPutCallback,
                 pointList,
                 config,
-                retryTimes
+                retryTimes,
+                writeContext
         );
         return httpCallback;
     }
@@ -97,7 +104,8 @@ public class HttpResponseCallbackFactory {
             final String address,
             final List<MultiFieldPoint> pointList,
             final Config config,
-            final int batchPutRetryTimes
+            final int batchPutRetryTimes,
+            final HAPolicy.WriteContext writeContext
     ) {
         FutureCallback<HttpResponse> httpCallback =
                 new MultiFieldBatchPutHttpResponseCallback(
@@ -106,7 +114,8 @@ public class HttpResponseCallbackFactory {
                         null,
                         pointList,
                         config,
-                        batchPutRetryTimes
+                        batchPutRetryTimes,
+                        writeContext
                 );
         return httpCallback;
     }

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/AbstractBatchPutRunnable.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/AbstractBatchPutRunnable.java
@@ -19,6 +19,7 @@ public abstract class AbstractBatchPutRunnable {
      * Http客户端
      */
     protected final HttpClient tsdbHttpClient;
+    protected final HttpClient secondaryClient;
     /**
      * 消费者队列控制器。
      * 在优雅关闭中，若消费者队列尚未结束，则CountDownLatch用于阻塞close()方法。
@@ -41,9 +42,10 @@ public abstract class AbstractBatchPutRunnable {
     protected int batchPutTimeLimit;
     protected final RateLimiter rateLimiter;
 
-    public AbstractBatchPutRunnable(DataQueue dataQueue, HttpClient httpclient, CountDownLatch countDownLatch, Config config, RateLimiter rateLimiter) {
+    public AbstractBatchPutRunnable(DataQueue dataQueue, HttpClient httpclient, HttpClient secondaryClient, CountDownLatch countDownLatch, Config config, RateLimiter rateLimiter) {
         this.dataQueue = dataQueue;
         this.tsdbHttpClient = httpclient;
+        this.secondaryClient = secondaryClient;
         this.countDownLatch = countDownLatch;
         this.batchSize = config.getBatchPutSize();
         this.batchPutTimeLimit = config.getBatchPutTimeLimit();

--- a/src/main/java/com/aliyun/hitsdb/client/consumer/ConsumerFactory.java
+++ b/src/main/java/com/aliyun/hitsdb/client/consumer/ConsumerFactory.java
@@ -7,8 +7,8 @@ import com.aliyun.hitsdb.client.util.guava.RateLimiter;
 
 public class ConsumerFactory {
 
-    public static Consumer createConsumer(DataQueue buffer, HttpClient httpclient, RateLimiter rateLimiter, Config config) {
-        DefaultBatchPutConsumer consumer = new DefaultBatchPutConsumer(buffer, httpclient, rateLimiter, config);
+    public static Consumer createConsumer(DataQueue buffer, HttpClient httpclient, HttpClient secondaryClient, RateLimiter rateLimiter, Config config) {
+        DefaultBatchPutConsumer consumer = new DefaultBatchPutConsumer(buffer, httpclient, secondaryClient, rateLimiter, config);
         return consumer;
     }
 

--- a/src/main/java/com/aliyun/hitsdb/client/http/HttpAPI.java
+++ b/src/main/java/com/aliyun/hitsdb/client/http/HttpAPI.java
@@ -11,12 +11,15 @@ public interface HttpAPI {
     String DUMP_META = "/api/dump_meta";
     String LOOKUP = "/api/search/lookup";
     String VERSION = "/api/version";
+    String MAIN_CLUSTER_TIME = "/api/set_cluster?mainClusterTime";
 
     String UPDATE_LAST = "/api/updatelast";
 
     String TRUNCATE = "/api/truncate";
 
     String DELETE_ALL_TABLE = "/api/delete_all_table";
+
+    String HEALTH = "/api/health";
 
     String VIP_HEALTH = "/api/vip_health";
 

--- a/src/main/java/com/aliyun/hitsdb/client/util/HealthManager.java
+++ b/src/main/java/com/aliyun/hitsdb/client/util/HealthManager.java
@@ -4,11 +4,6 @@ import com.aliyun.hitsdb.client.http.HttpAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Map;
 import java.util.concurrent.*;
 
@@ -52,6 +47,9 @@ public class HealthManager {
         this.watchers.remove(host);
     }
 
+    public void unWatchAll() {
+        this.watchers.clear();
+    }
 
     private final class WatchRunnable implements Runnable {
 
@@ -79,7 +77,7 @@ public class HealthManager {
         if (!host.startsWith("http")) {
             host = "http://" + host;
         }
-        String url = host + HttpAPI.VIP_HEALTH;
+        String url = host + HttpAPI.HEALTH;
         if (LOG.isDebugEnabled()) {
             LOG.debug("start to check {} ", host);
         }

--- a/src/test/java/com/aliyun/hitsdb/client/TestClientHA.java
+++ b/src/test/java/com/aliyun/hitsdb/client/TestClientHA.java
@@ -1,0 +1,416 @@
+package com.aliyun.hitsdb.client;
+
+import com.aliyun.hitsdb.client.callback.BatchPutDetailsCallback;
+import com.aliyun.hitsdb.client.callback.MultiFieldBatchPutDetailsCallback;
+import com.aliyun.hitsdb.client.value.request.*;
+import com.aliyun.hitsdb.client.value.response.batch.DetailsResult;
+import com.aliyun.hitsdb.client.value.response.batch.MultiFieldDetailsResult;
+import com.aliyun.hitsdb.client.value.type.Aggregator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by yunxing on 2022/2/25.
+ */
+public class TestClientHA {
+    final AtomicInteger succNum = new AtomicInteger();
+    final AtomicInteger failNum = new AtomicInteger();
+
+    private MultiFieldBatchPutDetailsCallback getMultiFieldDetailsCallback() {
+        MultiFieldBatchPutDetailsCallback callback = new MultiFieldBatchPutDetailsCallback() {
+
+            @Override
+            public void response(String address, List<MultiFieldPoint> points, MultiFieldDetailsResult result) {
+                succNum.addAndGet(points.size());
+                System.out.println("业务回调成功");
+            }
+
+            @Override
+            public void failed(String address, List<MultiFieldPoint> points, Exception ex) {
+                failNum.addAndGet(points.size());
+                System.err.println("业务回调出错！");
+                ex.printStackTrace();
+            }
+        };
+        return callback;
+    }
+
+    private BatchPutDetailsCallback getDetailsCallback() {
+        BatchPutDetailsCallback callback = new BatchPutDetailsCallback() {
+
+            @Override
+            public void response(String address, List<Point> points, DetailsResult result) {
+                succNum.addAndGet(points.size());
+                System.out.println("业务回调成功");
+            }
+
+            @Override
+            public void failed(String address, List<Point> points, Exception ex) {
+                failNum.addAndGet(points.size());
+                System.err.println("业务回调出错！");
+                ex.printStackTrace();
+            }
+        };
+        return callback;
+    }
+
+    /**
+     * @author yunxing
+     * @description Test case for 4 query HA policy under HA switch :
+     *                  SecondaryPreferred, PrimaryPreferred, Primary and Secondary.
+     *              Attention: We must start up 2 cluster before testing, and follow the instruction during testing
+     * @throws InterruptedException
+     */
+    @Test
+    public void testHASwitch() throws InterruptedException {
+        final String metric = "TestClientQueryHA";
+        final String tagName = "_id";
+        final String tagValue = "tagv";
+        final String mainIp = "127.0.0.1";
+        final int mainPort = 3002;
+        final String secondaryIp = "127.0.0.1";
+        final int secondaryPort = 3003;
+        int checkCount = 1;
+        int checkInterval = 20;
+        HashMap<String, String> tags = new HashMap<String, String>() {{ put(tagName, tagValue);}};
+
+
+        long currentSecond = System.currentTimeMillis() / 1000;
+        int value = 1;
+        Boolean failed = false;
+        Point point = Point.metric(metric).tag(tagName, tagValue).value(currentSecond, value).build();
+        MultiFieldPoint mpoint = MultiFieldPoint.metric(metric).tag(tagName, tagValue).timestamp(currentSecond).field("field", value).build();
+
+        Query query = Query.timeRange(currentSecond - 0, currentSecond + 1)
+                .sub(SubQuery.metric(metric).aggregator(Aggregator.NONE).tag(tags).build()).build();
+        MultiFieldQuery mquery = MultiFieldQuery.timeRange(currentSecond - 0, currentSecond + 1)
+                .sub(MultiFieldSubQuery.metric(metric).tags(tags)
+                        .fieldsInfo(new MultiFieldSubQueryDetails.Builder("*", Aggregator.NONE).build())
+                        .build())
+                .build();
+        LastPointQuery lastQuery = LastPointQuery
+                .builder().backScan(0).msResolution(true)
+                .sub(LastPointSubQuery.builder(metric, tags).build()).build();
+        LastPointQuery mlastQuery = LastPointQuery
+                .builder().backScan(0).msResolution(true)
+                .sub(LastPointSubQuery.builder(metric, new ArrayList<String>() {{
+                    add("*");
+                }}, tags).build()).build();
+
+        // STEP 1: 创建 主、备 tsdb client以及 PrimaryPreferred、Primary、SecondaryPreferred、Secondary四种策略的tsdb client
+
+        TSDBConfig config = TSDBConfig.address(mainIp, mainPort)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient tsdb1 = new TSDBClient(config);
+
+        TSDBConfig config2 = TSDBConfig.address(secondaryIp, secondaryPort)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient tsdb2 = new TSDBClient(config2);
+
+        HAPolicy primaryPreferredPolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.PrimaryPreferred, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.PrimaryPreferred, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+        TSDBConfig primaryPreferredConfig = TSDBConfig.address(mainIp, mainPort).addHAPolicy(primaryPreferredPolicy)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient primaryPreferredTsdb = new TSDBClient(primaryPreferredConfig);
+
+        HAPolicy primaryPolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.Primary, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.Primary, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+        TSDBConfig primaryConfig = TSDBConfig.address(mainIp, mainPort).addHAPolicy(primaryPolicy)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient primaryTsdb = new TSDBClient(primaryConfig);
+
+
+        HAPolicy secondaryPreferredpolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.SecondaryPreferred, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.SecondaryPreferred, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+        TSDBConfig secondaryPreferredConfig = TSDBConfig.address(mainIp, mainPort).addHAPolicy(secondaryPreferredpolicy)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient secondaryPreferredTsdb = new TSDBClient(secondaryPreferredConfig);
+
+        HAPolicy secondaryPolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.Secondary, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.Secondary, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+        TSDBConfig secondaryConfig = TSDBConfig.address(mainIp, mainPort).addHAPolicy(secondaryPolicy)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient secondaryTsdb = new TSDBClient(secondaryConfig);
+
+        // STEP 2: 测试正常情况下单值、多值、同步、异步写,查询正常
+        {
+            succNum.set(0);
+            failNum.set(0);
+
+            testSuccess(tsdb1, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(tsdb2, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(primaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(primaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(secondaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(secondaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            Thread.sleep(5 * 1000);
+
+            Assert.assertEquals(12, succNum.get());
+            Assert.assertEquals(0, failNum.get());
+        }
+
+
+        // STEP 3: 测试主 fail
+        {
+            succNum.set(0);
+            failNum.set(0);
+
+            System.out.println("please kill primary cluster!");
+            while (true) {
+                try {
+                    tsdb1.getVersionInfo();
+                } catch (Exception e) {
+                    break;
+                }
+                System.out.println("please kill primary cluster!");
+                Thread.sleep(3 * 1000);
+            }
+
+            // tsdb1 失败,tsdb2 成功, 带主备切换配置的同步、异步写入和查询能成功执行
+            testFailed(tsdb1, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(tsdb2, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(primaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testFailed(primaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(secondaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(secondaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            Thread.sleep(5 * 1000);
+
+            Assert.assertEquals(8, succNum.get());
+            Assert.assertEquals(4, failNum.get());
+        }
+
+
+        // STEP 4: 测试主拉起，备 fail
+        {
+            succNum.set(0);
+            failNum.set(0);
+
+            while (true) {
+                try {
+                    tsdb1.getVersionInfo();
+                    break;
+                } catch (Exception e) {
+                    System.out.println("please start up primary cluster!");
+                    Thread.sleep(5 * 1000);
+                }
+            }
+
+            System.out.println("please kill secondary cluster!");
+            Thread.sleep(5 * 1000);
+            while (true) {
+                try {
+                    tsdb2.getVersionInfo();
+                } catch (Exception e) {
+                    break;
+                }
+                System.out.println("please kill secondary cluster!");
+                Thread.sleep(5 * 1000);
+            }
+
+            // tsdb1 成功,tsdb2 成功, 带主备切换配置的同步、异步写入和查询能成功执行
+
+            testSuccess(tsdb1, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testFailed(tsdb2, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(primaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(primaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testSuccess(secondaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            testFailed(secondaryTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+
+            Thread.sleep(5 * 1000);
+
+            Assert.assertEquals(8, succNum.get());
+            Assert.assertEquals(4, failNum.get());
+        }
+    }
+
+    /**
+     * @author yunxing
+     * @description this testcase will not stop,
+     *      kill primary cluster or secondary cluster in turn to check ha swtich
+     * @throws InterruptedException
+     */
+    @Test
+    public void testForeverWrite() throws InterruptedException {
+        final String metric = "TestForeverWrite";
+        final String tagName = "_id";
+        final String tagValue = "tagv";
+        final String mainIp = "127.0.0.1";
+        final int mainPort = 3002;
+        final String secondaryIp = "127.0.0.1";
+        final int secondaryPort = 3003;
+        int checkCount = 30;
+        int checkInterval = 20;
+
+        long currentSecond = System.currentTimeMillis() / 1000;
+        int value = 1;
+        HashMap<String, String> tags = new HashMap<String, String>() {{ put(tagName, tagValue);}};
+        Point point = Point.metric(metric).tag(tagName, tagValue).value(currentSecond, value).build();
+        MultiFieldPoint mpoint = MultiFieldPoint.metric(metric).tags(tags).timestamp(currentSecond).field("field", value).build();
+
+        Query query = Query.timeRange(currentSecond - 0, currentSecond + 1)
+                .sub(SubQuery.metric(metric).aggregator(Aggregator.NONE).tag(tags).build()).build();
+        MultiFieldQuery mquery = MultiFieldQuery.timeRange(currentSecond - 0, currentSecond + 1)
+                .sub(MultiFieldSubQuery.metric(metric).tags(tags)
+                        .fieldsInfo(new MultiFieldSubQueryDetails.Builder("*", Aggregator.NONE).build())
+                        .build())
+                .build();
+        LastPointQuery lastQuery = LastPointQuery
+                .builder().backScan(0).msResolution(true)
+                .sub(LastPointSubQuery.builder(metric, tags).build()).build();
+        LastPointQuery mlastQuery = LastPointQuery
+                .builder().backScan(0).msResolution(true)
+                .sub(LastPointSubQuery.builder(metric, new ArrayList<String>() {{
+                    add("*");
+                }}, tags).build()).build();
+
+        // STEP 1: TEST FOR HAPolicy.RetryRule.Secondary AND HAPolicy.RetryRule.SecondaryPreferred
+        HAPolicy primaryPreferredPolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.PrimaryPreferred, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.PrimaryPreferred, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+
+
+        TSDBConfig primaryPreferredConfig = TSDBConfig.address(mainIp, mainPort).addHAPolicy(primaryPreferredPolicy)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .config();
+        TSDBClient primaryPreferredTsdb = new TSDBClient(primaryPreferredConfig);
+
+        HAPolicy SecondaryPreferredpolicy = HAPolicy.addSecondaryCluster(secondaryIp, secondaryPort)
+                .setQueryRetryRule(HAPolicy.RetryRule.SecondaryPreferred, 1)
+                .setWriteRetryRule(HAPolicy.RetryRule.SecondaryPreferred, 1)
+                .setFailoverRule(checkCount, checkInterval).build();
+        TSDBConfig SecondaryPreferredConfig = TSDBConfig.address(mainIp, mainPort)
+                .listenMultiFieldBatchPut(getMultiFieldDetailsCallback())
+                .listenBatchPut(getDetailsCallback())
+                .addHAPolicy(SecondaryPreferredpolicy).config();
+        TSDBClient secondaryPreferredTsdb = new TSDBClient(SecondaryPreferredConfig);
+
+
+
+        while (true) {
+            testSuccess(primaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+            testSuccess(secondaryPreferredTsdb, point, mpoint, query, mquery, lastQuery, mlastQuery);
+            Thread.sleep(1000);
+            Assert.assertEquals(0, failNum.get());
+        }
+    }
+
+
+    private void testSuccess(TSDBClient client, Point point, MultiFieldPoint mpoint, Query query, MultiFieldQuery mquery,
+                             LastPointQuery lastQuery, LastPointQuery mlastQuery) {
+        client.putSync(point);
+        client.multiFieldPutSync(mpoint);
+        client.put(point);
+        client.multiFieldPut(mpoint);
+
+        Assert.assertTrue(client.multiFieldQuery(mquery).size() > 0);
+        Assert.assertTrue(client.query(query).size() > 0);
+        Assert.assertTrue(client.queryLast(lastQuery).size() > 0);
+        Assert.assertTrue(client.multiFieldQueryLast(mlastQuery).size() > 0);
+    }
+
+    private void testFailed(TSDBClient client, Point point, MultiFieldPoint mpoint, Query query, MultiFieldQuery mquery,
+                            LastPointQuery lastQuery, LastPointQuery mlastQuery) {
+        boolean failed = false;
+        try {
+            client.putSync(point);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+        failed = false;
+        try {
+            client.multiFieldPutSync(mpoint);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+        client.put(point);
+        client.multiFieldPut(mpoint);
+
+        failed = false;
+        try {
+            client.multiFieldQuery(mquery);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+        failed = false;
+        try {
+            client.query(query);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+        failed = false;
+        try {
+            client.queryLast(lastQuery);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+        failed = false;
+        try {
+            client.multiFieldQueryLast(mlastQuery);
+        } catch (Exception e) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail();
+        }
+    }
+
+}


### PR DESCRIPTION
● 容灾:【主备切换】SDK使用master接口比较两个集群实例时间戳大小，时间戳大的为主集群，小的为备集群。当和自身记录的主备关系变化时，执行主备切换逻辑，即优先写入的实例切换。
● 容错： 优化原有逻辑 :
具体步骤如下图： 
  a. SDK 通过访问两个集群（tsdb-1, tsdb-2）master接口确定主（tsdb-1）备(tsdb-2)关系
  b. 定时对tsdb-1执行访问请求, 当tsdb-1出现异常时，执行N次（默认3次）访问重试，N次失败访问转发到备（tsdb-2)
![image](https://user-images.githubusercontent.com/12252633/176136858-62dc1874-3f98-460e-b9a5-a573abd27adb.png)

  c. 重试失败M次（M>=N）执行ha switch的容错机制，即访问全部切换到备(tsdb-2)
  d. 定期对主(tsdb-1)进行健康检查
  e.  当主（tsdb-1）健康（health），重制状态将读写流量切回到主(tsdb-1)
![image](https://user-images.githubusercontent.com/12252633/176136902-749c7fce-d9ba-42be-a2a4-af0c026dd3f5.png)

